### PR TITLE
💚 make featured area on dashboard two column for mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -635,6 +635,23 @@ code {
 .text-transparent {
 	color: transparent;
 }
+.featured {
+	.featured-number {
+		font-size: 4em;
+		line-height: 1.5em;
+		font-weight: 300;
+
+		@media (max-width: $size-lg) {
+			font-size: 3em;
+			line-height: 1.25em;
+		}
+	}
+	.featured-description {
+		@media (max-width: $size-lg) {
+			font-size: .75rem;
+		}
+	}
+}
 
 // display
 .d-flex > * {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -20,38 +20,38 @@
 
 			<!-- stored songs count -->
 			<div class="columns" v-if="ready.songs && ready.setlists">
-				<div class="column col-3 col-xl-6 col-sm-12 mt-4">
+				<div class="column col-3 col-xl-6 mt-4">
 					<div class="panel">
-						<div class="panel-body text-center pb-3">
-							<div class="text-huge">{{ Object.keys(songs).length }}</div>
-							<div class="panel-title h5"><ion-icon name="musical-notes" class="mr-2"></ion-icon> {{ $t('widget.songsStored') }}</div>
+						<div class="panel-body text-center pb-3 featured">
+							<div class="featured-number">{{ Object.keys(songs).length }}</div>
+							<div class="panel-title h5 featured-description"><ion-icon name="musical-notes" class="mr-2"></ion-icon> {{ $t('widget.songsStored') }}</div>
 						</div>
 					</div>
 				</div>
 				<!-- stored setlists count -->
-				<div class="column col-3 col-xl-6 col-sm-12 mt-4">
+				<div class="column col-3 col-xl-6 mt-4">
 					<div class="panel">
-						<div class="panel-body text-center pb-3">
-							<div class="text-huge">{{ Object.keys(setlists).length }}</div>
-							<div class="panel-title h5"><ion-icon name="list" class="mr-2"></ion-icon> {{ $t('widget.setlistsStored') }}</div>
+						<div class="panel-body text-center pb-3 featured">
+							<div class="featured-number">{{ Object.keys(setlists).length }}</div>
+							<div class="panel-title h5 featured-description"><ion-icon name="list" class="mr-2"></ion-icon> {{ $t('widget.setlistsStored') }}</div>
 						</div>
 					</div>
 				</div>
 				<!-- performed songs count -->
-				<div class="column col-3 col-xl-6 col-sm-12 mt-4">
+				<div class="column col-3 col-xl-6 mt-4">
 					<div class="panel">
-						<div class="panel-body text-center pb-3">
-							<div class="text-huge"><span class="text-gray">~</span>{{ songsPerformed }}</div>
-							<div class="panel-title h5"><ion-icon name="mic-outline" class="mr-2"></ion-icon> {{ $t('widget.songsPerformed') }}</div>
+						<div class="panel-body text-center pb-3 featured">
+							<div class="featured-number"><span class="text-gray">~</span>{{ songsPerformed }}</div>
+							<div class="panel-title h5 featured-description"><ion-icon name="mic-outline" class="mr-2"></ion-icon> {{ $t('widget.songsPerformed') }}</div>
 						</div>
 					</div>
 				</div>
 				<!-- used languages count -->
-				<div class="column col-3 col-xl-6 col-sm-12 mt-4">
+				<div class="column col-3 col-xl-6 mt-4">
 					<div class="panel">
-						<div class="panel-body text-center pb-3">
-							<div class="text-huge">{{ languagesUsed }}</div>
-							<div class="panel-title h5"><ion-icon name="globe-outline" class="mr-2"></ion-icon> {{ $t('widget.languages') }}</div>
+						<div class="panel-body text-center pb-3 featured">
+							<div class="featured-number">{{ languagesUsed }}</div>
+							<div class="panel-title h5 featured-description"><ion-icon name="globe-outline" class="mr-2"></ion-icon> {{ $t('widget.languages') }}</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Description of the Change

Featured tiles on narrow viewports took too much space. They are now always two-column for small viewports and have a smaller font-size for < 960px.

## Benefits

Better overview of content on narrow viewports.

![image](https://user-images.githubusercontent.com/5441654/111957615-8b5d6200-8aec-11eb-97c9-8e96d02df2c1.png)

## Applicable Issues

Closes #46 
