### PR TITLE
🔨 watch user object to update profile on page load

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -305,6 +305,13 @@ export default {
 				type: 'primary'
 			});
 		}
+	},
+	watch: {
+		userObject () {
+			this.profile.displayName = this.userObject.displayName;
+			this.profile.email = this.userObject.email;
+			this.profile.photoURL = this.userObject.photoURL;
+		}
 	}
 }
 </script>


### PR DESCRIPTION
## Description of the Change

A watcher was added to react to changes of the user object.

## Benefits

If the settings page is refreshed, profile information are now properly loaded, once the user object is available or changed.

## Applicable Issues

None
