### PR TITLE
Minor style fixes

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -261,9 +261,13 @@ h2, .h2 {
 	}
 }
 h3, .h3 {
-	font-size: 1em;
+	font-size: 1.2em;
 	letter-spacing: 2px;
 	padding-bottom: 1em;
+}
+h4, .h4 {
+	font-size: 1em;
+	letter-spacing: 2px;
 }
 h5, .h5 {
 	letter-spacing: 2px;

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -585,9 +585,13 @@ a {
 			font-weight: 400;
 		}
 	}
-	& .tile-title,
+	& .tile-title {
+		margin: -.1rem 0 -.1rem 0 !important;
+		line-height: 1rem;
+	}
 	& .tile-subtitle {
-		line-height: .85rem;
+		margin: 0 0 -.2rem 0 !important;
+		line-height: 1rem;
 	}
 	&.tile-hover:hover {
 		background: $bg-color-dark;


### PR DESCRIPTION
## Description of the Change

Title text in tiles was cut at the bottom due to a line height that was too small. This was fixed, as well as a missing definition for h4 sizing.

## Benefits

Text is displayed properly again.

## Applicable Issues

None.
