### PR TITLE
General app config

### DIFF
--- a/demo.import.json
+++ b/demo.import.json
@@ -1,4 +1,9 @@
 {
+  "config": {
+    "contact": {
+      "email": "support@songdrive.com"
+    }
+  },
   "languages": {
     "de": {
       "label": "Deutsch"
@@ -488,7 +493,7 @@
   },
   "users": {
     "ABCXKI9aaiQbJljzxrFMWA4Mn9t1": {
-      "email": "john.doe@songdrive.de",
+      "email": "john.doe@songdrive.com",
       "name": "John Doe",
       "role": "admin"
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -148,6 +148,7 @@
 					:users="users"
 					:registrations="registrations"
 					:languages="languages"
+					:config="config"
 					:ready="ready"
 				></router-view>
 			</div>
@@ -248,6 +249,7 @@ export default {
 			users: {},
 			registrations: {},
 			languages: {},
+			config: {},
 			// loading indicators
 			ready: {
 				users: false,
@@ -256,6 +258,7 @@ export default {
 				setlists: false,
 				tags: false,
 				languages: false,
+				config: false,
 			},
 			// db table listeners
 			listener: {
@@ -265,6 +268,7 @@ export default {
 				setlists: null,
 				tags: null,
 				languages: null,
+				config: null
 			},
 			// modals
 			open: false,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -32,6 +32,7 @@
     "launch": "Starten",
     "present": "Präsentieren",
     "reset": "Zurücksetzen",
+    "saveConfig": "Konfiguration Speichern",
     "saveProfile": "Profil Speichern",
     "show": "Anzeigen",
     "shuffle": "Zufällig",
@@ -102,7 +103,7 @@
     "content": "Inhalt",
     "creator": "Ersteller",
     "date": "Datum der Veranstaltung",
-    "email": "Email",
+    "email": "E-Mail",
     "isocode": "ISO Code",
     "key": "Key",
     "label": "Bezeichnung",
@@ -115,6 +116,7 @@
     "role": "Rolle",
     "songs": "Songs",
     "subtitle": "Untertitel",
+    "supportEmail": "Support E-Mail Adresse",
     "tags": "Tags",
     "title": "Titel",
     "translations": "Übersetzungen",
@@ -213,6 +215,7 @@
   },
   "text": {
     "cannotBeUndone": "Das kann nicht rückgängig gemacht werden.",
+    "configureApp": "Allgemeine Anwendungsparameter verwalten",
     "confirmationSubject": "[SongDrive] Benutzerkonto aktiviert",
     "confirmationBody": "Hallo {0},\n\ndu wurdest soeben für die Nutzung von SongDrive freigeschaltet. Du kannst dich nun einloggen unter {1}\n\nKontaktiere uns gern, wenn du Fragen hast.\n\nDein SongDrive-Team\n\n",
     "createNewAccount": "Erstelle ein neues SongDrive Konto.",
@@ -259,6 +262,8 @@
     "songTuning": "Tonart"
   },
   "toast": {
+    "configUpdated": "Konfiguration aktualisiert",
+    "configUpdatedText": "Die Einstellungen wurden erfolgreich gespeichert.",
     "copiedToClipboard": "In die Zwischenablage kopiert",
     "databaseExported": "Datenbank exportiert",
     "databaseExportedText": "Die gesamte Datenbank wurde erfolgreich im JSON Format exportiert.",
@@ -332,7 +337,9 @@
     "transposeUp": "Einen Halbton hoch transponieren"
   },
   "widget": {
+    "appearance": "Ansicht",
     "backup": "Backup",
+    "configuration": "Konfiguration",
     "goToSetlists": "Alle Setlisten anzeigen",
     "goToSongs": "Alle Songs anzeigen",
     "keys": "Tonarten",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -214,7 +214,7 @@
   "text": {
     "cannotBeUndone": "Das kann nicht rückgängig gemacht werden.",
     "confirmationSubject": "[SongDrive] Benutzerkonto aktiviert",
-    "confirmationBody": "Hallo {0},\n\ndu wurdest soeben für die Nutzung von SongDrive freigeschaltet. Du kannst dich nun einloggen unter {1}.\n\nKontaktiere uns gern, wenn du Fragen hast.\n\nDein SongDrive-Team\n\n",
+    "confirmationBody": "Hallo {0},\n\ndu wurdest soeben für die Nutzung von SongDrive freigeschaltet. Du kannst dich nun einloggen unter {1}\n\nKontaktiere uns gern, wenn du Fragen hast.\n\nDein SongDrive-Team\n\n",
     "createNewAccount": "Erstelle ein neues SongDrive Konto.",
     "customizeProfile": "Passe deine Profildaten an",
     "customizeUi": "Passe die Benutzeroberfläche an",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,7 +214,7 @@
   "text": {
     "cannotBeUndone": "This cannot be undone.",
     "confirmationSubject": "[SongDrive] Your account got activated",
-    "confirmationBody": "Hi {0},\n\nYou were approved to use SongDrive just now. You can now log in under {1}.\n\nIf you have any questions, please contact us!\n\nYour SongDrive-Team\n\n",
+    "confirmationBody": "Hi {0},\n\nYou were approved to use SongDrive just now. You can now log in under {1}\n\nIf you have any questions, please contact us!\n\nYour SongDrive-Team\n\n",
     "createNewAccount": "Create a new SongDrive account.",
     "customizeProfile": "Customize your profile data",
     "customizeUi": "Customize the user interface",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,6 +32,7 @@
     "launch": "Launch",
     "present": "Present",
     "reset": "Reset",
+    "saveConfig": "Save Configuration",
     "saveProfile": "Save Profile",
     "show": "Show",
     "shuffle": "Shuffle",
@@ -115,6 +116,7 @@
     "role": "Role",
     "songs": "Songs",
     "subtitle": "Subtitle",
+    "supportEmail": "Support email address",
     "tags": "Tags",
     "title": "Title",
     "translations": "Translations",
@@ -213,6 +215,7 @@
   },
   "text": {
     "cannotBeUndone": "This cannot be undone.",
+    "configureApp": "Manage general app parameters",
     "confirmationSubject": "[SongDrive] Your account got activated",
     "confirmationBody": "Hi {0},\n\nYou were approved to use SongDrive just now. You can now log in under {1}\n\nIf you have any questions, please contact us!\n\nYour SongDrive-Team\n\n",
     "createNewAccount": "Create a new SongDrive account.",
@@ -259,6 +262,8 @@
     "songTuning": "Song key"
   },
   "toast": {
+    "configUpdated": "Configuration updated",
+    "configUpdatedText": "Configuration data was successfully saved.",
     "copiedToClipboard": "Copied to clipboard",
     "databaseExported": "Database exported",
     "databaseExportedText": "The whole database was successfully exported in JSON format.",
@@ -332,7 +337,9 @@
     "transposeUp": "Transpose up a semitone"
   },
   "widget": {
+    "appearance": "Appearance",
     "backup": "Backup",
+    "configuration": "Configuration",
     "goToSetlists": "Go to Setlists",
     "goToSongs": "Go to Songs",
     "keys": "Keys",

--- a/src/partials/UserUnconfirmed.vue
+++ b/src/partials/UserUnconfirmed.vue
@@ -9,7 +9,7 @@
 		<div class="message">
 			<h3>{{ $t('text.waitingForApproval') }}</h3>
 			<p>{{ $t('text.notApprovedYet') }}</p>
-			<p v-html="$t('text.unconfirmedMistake', ['yo@songdrive.de'])"></p>
+			<p v-if="ready.config && config.contact.email" v-html="$t('text.unconfirmedMistake', [config.contact.email])"></p>
 			<button class="btn btn-secondary d-block stretch mt-4" @click="$emit('signOut')">
 				{{ $t('button.signOut') }} <ion-icon name="log-out-outline" class="icon-right"></ion-icon>
 			</button>
@@ -19,7 +19,8 @@
 
 <script>
 export default {
-	name: 'user-unconfirmed'
+	name: 'user-unconfirmed',
+	props: ['ready', 'config']
 }
 </script>
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -125,7 +125,7 @@
 								</div>
 								<div class="tile-action">
 									<a
-										:href="'mailto:' + u.email + '?' + confirmationMail"
+										:href="'mailto:' + u.email + '?' + confirmationMail(u.name)"
 										class="btn btn-link btn-action tooltip"
 										:data-tooltip="$t('tooltip.sendConfirmationMail')"
 									>
@@ -447,6 +447,10 @@ export default {
 				this.$notify({ title: error.code, text: error.message, type: 'error' });
 			});
 		},
+		confirmationMail (name) {
+			return 'subject=' + encodeURIComponent(this.$t('text.confirmationSubject'))
+				+ '&body=' + encodeURIComponent(this.$t('text.confirmationBody', [name, window.location.origin]))
+		},
 		exportDb () {
 			let data = {
 				'songs': this.songs,
@@ -481,10 +485,6 @@ export default {
 		numberOfLanguages () {
 			return Object.keys(this.languages).length;
 		},
-		confirmationMail () {
-			return 'subject=' + encodeURIComponent(this.$t('text.confirmationSubject'))
-				+ '&body=' + encodeURIComponent(this.$t('text.confirmationBody', [this.userObject.displayName, 'https://songdrive.de']))
-		}
 	},
 	watch: {
 		userObject () {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -72,8 +72,8 @@
 				<div class="column col-4 col-xl-6 col-md-12 mt-4">
 					<div class="panel" v-if="ready.languages">
 						<div class="panel-header text-center">
-							<ion-icon name="cog-outline" class="icon-2x"></ion-icon>
-							<div class="panel-title h5 mt-1">{{ $t('app.name') }}</div>
+							<ion-icon name="color-palette-outline" class="icon-2x"></ion-icon>
+							<div class="panel-title h5 mt-1">{{ $t('widget.appearance') }}</div>
 							<div class="panel-subtitle text-gray">{{ $t('text.customizeUi') }}</div>
 						</div>
 						<div class="panel-body">
@@ -281,6 +281,33 @@
 						</div>
 					</div>
 				</div>
+				<!-- configuration -->
+				<div class="column col-4 col-xl-6 col-md-12 mt-4">
+					<div class="panel">
+						<div class="panel-header text-center">
+							<ion-icon name="cog-outline" class="icon-2x"></ion-icon>
+							<div class="panel-title h5 mt-1">{{ $t('widget.configuration') }}</div>
+							<div class="panel-subtitle text-gray">{{ $t('text.configureApp') }}</div>
+						</div>
+						<div class="panel-body">
+							<div v-if="ready.config" class="form-group">
+								<label class="form-label" for="supportEmail">{{ $t('field.supportEmail') }}</label>
+								<input
+									v-model="configuration.contact.email"
+									class="form-input"
+									id="supportEmail"
+									type="text"
+									placeholder="support@domain.tld"
+								/>
+							</div>
+						</div>
+						<div class="panel-footer mt-5">
+							<button class="btn btn-primary btn-block text-uppercase" @click="updateConfig">
+								<ion-icon name="save-outline" class="icon-left"></ion-icon> {{ $t('button.saveConfig') }}
+							</button>
+						</div>
+					</div>
+				</div>
 				<!-- backup administration -->
 				<div class="column col-4 col-xl-6 col-md-12 mt-4">
 					<div class="panel">
@@ -293,7 +320,7 @@
 							<button class="btn btn-primary btn-block text-uppercase mb-2" @click="exportDb">
 								<ion-icon name="archive-outline" class="icon-left"></ion-icon> {{ $t('button.export') }}
 							</button>
-							<button class="btn btn-primary btn-block text-uppercase" @click="modal.importdata=true">
+							<button class="btn btn-danger btn-block text-uppercase" @click="modal.importdata=true">
 								<ion-icon name="download-outline" class="icon-left"></ion-icon> {{ $t('button.import') }}
 							</button>
 						</div>
@@ -397,7 +424,8 @@ export default {
 		'tags',
 		'songs',
 		'setlists',
-		'languages'
+		'languages',
+		'config'
 	],
 	data () {
 		return {
@@ -406,6 +434,11 @@ export default {
 				role: this.roleName,
 				email: this.userObject.email,
 				photoURL: this.userObject.photoURL
+			},
+			configuration: {
+				contact: {
+					email: this.config?.contact?.email
+				}
 			},
 			modal: {
 				userset: false,
@@ -447,6 +480,21 @@ export default {
 				this.$notify({ title: error.code, text: error.message, type: 'error' });
 			});
 		},
+		updateConfig () {
+			this.$db.collection('config').doc('contact').update({
+				email: this.configuration.contact.email
+			}).then(() => {
+				// Config updated successfully!
+				this.$notify({
+					title: this.$t('toast.configUpdated'),
+					text: this.$t('toast.configUpdatedText'),
+					type: 'primary'
+				});
+			}).catch((error) => {
+				// An error happened.
+				this.$notify({ title: error.code, text: error.message, type: 'error' });
+			});
+		},
 		confirmationMail (name) {
 			return 'subject=' + encodeURIComponent(this.$t('text.confirmationSubject'))
 				+ '&body=' + encodeURIComponent(this.$t('text.confirmationBody', [name, window.location.origin]))
@@ -474,7 +522,7 @@ export default {
 			let uiLanguages = {};
 			Object.keys(this.$i18n.messages).forEach(key => {
 				if (this.languages[key]) {
-					uiLanguages[key] = this.languages[key].label; // TODO: check if key esists in this.languages
+					uiLanguages[key] = this.languages[key].label; // TODO: check if key exists in this.languages
 				}
 			})
 			return uiLanguages;
@@ -491,6 +539,9 @@ export default {
 			this.profile.displayName = this.userObject.displayName;
 			this.profile.email = this.userObject.email;
 			this.profile.photoURL = this.userObject.photoURL;
+		},
+		config () {
+			this.configuration.contact.email = this.config.contact.email;
 		}
 	}
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -320,7 +320,7 @@
 							<button class="btn btn-primary btn-block text-uppercase mb-2" @click="exportDb">
 								<ion-icon name="archive-outline" class="icon-left"></ion-icon> {{ $t('button.export') }}
 							</button>
-							<button class="btn btn-danger btn-block text-uppercase" @click="modal.importdata=true">
+							<button class="btn btn-error btn-block text-uppercase" @click="modal.importdata=true">
 								<ion-icon name="download-outline" class="icon-left"></ion-icon> {{ $t('button.import') }}
 							</button>
 						</div>
@@ -501,6 +501,7 @@ export default {
 		},
 		exportDb () {
 			let data = {
+				'config': this.configuration,
 				'songs': this.songs,
 				'setlists': this.setlists,
 				'users': this.users,


### PR DESCRIPTION
## Description of the Change

This change adds a collection for app configuration, with a `contact` document with a `email` field.

## Benefits

The *Settings* page now contains a widget for a support email address. It's extensible with possible additional fields.
![image](https://user-images.githubusercontent.com/5441654/143627371-6138dbd8-bd4b-4c86-a31b-bce6dac06346.png)

## Applicable Issues

Closes #88 
