### PR TITLE
Permissions collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,58 +60,27 @@ This is how the SongDrive Dashboard currently looks like.
 4. Log in to your [Firebase account](https://console.firebase.google.com), hit the "Add a project" button and set up a project name and a server location
 5. Now you can add an app by clicking the "Web" button, choose a nickname and click "Next"
 6. Copy *API key* and *project ID* into your `.env` file
-7. Go back to your Firebase console, and click *Create Database* under Develop > Database. Choose *Start in production mode* and set the following security rules:
-
-    ```javascript
-    rules_version = '2';
-    service cloud.firestore {
-      match /databases/{database}/documents {
-        match /{document=**} {
-          allow read: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "reader"
-                      || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "performer"
-                      || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor";
-          allow read, write: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "admin";
-        }
-        match /setlists/{setlist} {
-          allow create, update: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "performer"
-                                || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor";
-          allow delete: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor"
-                        || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "performer" && request.auth.uid == resource.data.creator;
-        }
-        match /songs/{song} {
-          allow write: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor";
-        }
-        match /registrations/{user} {
-          allow create: if request.auth.uid != '';
-        }
-        match /users/{user} {
-          allow read: if request.auth.uid != '' && user == request.auth.uid;
-        }
-        match /config/{category} {
-          allow read: if request.auth.uid != '';
-        }
-      }
-    }
-    ```
-
+7. Go back to your Firebase console, and click *Create Database* under Develop > Database. Choose *Start in production mode* and paste the security rules that you can copy frome the [firestore.rules](./firestore.rules) file.
 8. Create the first user in the Firebase console under Build > Authentification > Add user. After that you'll see the User UID in the table. Copy that UID, navigate to Build > Firestore Database > + Start collection. Input *users* as Collection ID and click Next. Insert the copied UID as Document ID and add the following fields to the document:
     - `email` = string | *your email address*
     - `name` = string | *your name*
+
+9. To give necessary permisstions, click + Start collection again. Input *permissions* as Collection ID and click Next. Insert the copied UID as Document ID and add the following field to the document:
     - `role` = string | `admin`
 
-9. Now your app is ready to be launched. Either start the development server with hot reload at `localhost:8080` ...
+10. Now your app is ready to be launched. Either start the development server with hot reload at `localhost:8080` ...
 
     ```bash
     yarn serve
     ```
 
-10. ... or create an optimized production build with minification. All build files can be found in the `dist` directory.
+11. ... or create an optimized production build with minification. All build files can be found in the `dist` directory.
 
     ```bash
     yarn build
     ```
 
-11. (optional) You can import demo content if you don't like to start from scratch. First download the [demo data file](https://raw.githubusercontent.com/devmount/SongDrive/main/demo.import.json) from the repository. Sign in to SongDrive with your admin user, go to Settings > Import, select the downloaded demo file and import it. You can now have a look at 8 public domain songs, one demo setlist, several song tags, English and German languages and an additional test user.
+12. (optional) You can import demo content if you don't like to start from scratch. First download the [demo data file](https://raw.githubusercontent.com/devmount/SongDrive/main/demo.import.json) from the repository. Sign in to SongDrive with your admin user, go to Settings > Import, select the downloaded demo file and import it. You can now have a look at 8 public domain songs, one demo setlist, several song tags, English and German languages and an additional test user.
 
 ## Licence
 

--- a/demo.import.json
+++ b/demo.import.json
@@ -493,8 +493,12 @@
   },
   "users": {
     "ABCXKI9aaiQbJljzxrFMWA4Mn9t1": {
-      "email": "john.doe@songdrive.com",
-      "name": "John Doe",
+      "email": "john.doe@example.com",
+      "name": "John Doe"
+    }
+  },
+  "permissions": {
+    "ABCXKI9aaiQbJljzxrFMWA4Mn9t1": {
       "role": "admin"
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,32 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "reader"
+      						|| get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "performer"
+                  || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor";
+      allow read, write: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "admin";
+    }
+    match /setlists/{setlist} {
+      allow create, update: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "performer"
+                            || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor";
+      allow delete: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor"
+                    || get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "performer" && request.auth.uid == resource.data.creator;
+    }
+    match /songs/{song} {
+      allow write: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "editor";
+    }
+    match /registrations/{user} {
+      allow create: if request.auth.uid != '';
+    }
+    match /permissions/{user} {
+      allow write: if get(/databases/$(database)/documents/permissions/$(request.auth.uid)).data.role == "admin";
+    }
+    match /users/{user} {
+      allow read, write: if request.auth.uid != '' && user == request.auth.uid;
+    }
+    match /config/{category} {
+      allow read: if request.auth.uid != '';
+    }
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
 	<div id="app">
-		<div v-if="auth.ready && auth.user && ready.users && users[auth.user]" class="off-canvas off-canvas-sidebar-show">
+		<div v-if="auth.ready && auth.user && ready.users && users[auth.user] && ready.permissions && permissions[auth.user]" class="off-canvas off-canvas-sidebar-show">
 			<!-- off-screen toggle button -->
 			<a class="off-canvas-toggle btn btn-primary btn-action" @click="open = true">
 				<ion-icon name="menu" size="large"></ion-icon>
@@ -31,7 +31,7 @@
 								<label v-if="ready.songs" class="label py-1">{{ Object.keys(songs).length }}</label>
 								<label v-else class="label py-1"><div class="loading d-inline-block px-2"></div></label>
 								<button
-									v-if="userRoles()[users[auth.user].role] > 2"
+									v-if="userRoles()[permissions[auth.user].role] > 2"
 									class="btn btn-secondary btn-action btn-sm mx-2 tooltip tooltip-left"
 									:data-tooltip="$t('tooltip.songAdd')"
 									@click="modal.addsong = true"
@@ -48,7 +48,7 @@
 								<label v-if="ready.setlists" class="label py-1">{{ Object.keys(setlists).length }}</label>
 								<label v-else class="label py-1"><div class="loading d-inline-block px-2"></div></label>
 								<button
-									v-if="userRoles()[users[auth.user].role] > 1"
+									v-if="userRoles()[permissions[auth.user].role] > 1"
 									class="btn btn-secondary btn-action btn-sm mx-2 tooltip tooltip-left"
 									:data-tooltip="$t('tooltip.setlistAdd')"
 									@click="modal.addsetlist = true"
@@ -73,7 +73,7 @@
 									<div class="tile-content">
 										{{ userName }}
 										<div class="text-gray text-small">
-											{{ $t('role.' + users[auth.user].role) }}
+											{{ $t('role.' + permissions[auth.user].role) }}
 										</div>
 									</div>
 								</div>
@@ -140,16 +140,17 @@
 					:key="$route.fullPath"
 					:user="auth.user"
 					:userObject="auth.userObject"
-					:role="userRoles()[users[auth.user].role]"
-					:roleName="users[auth.user].role"
-					:songs="songs"
+					:role="userRoles()[permissions[auth.user].role]"
+					:roleName="permissions[auth.user].role"
+					:ready="ready"
+					:config="config"
+					:languages="languages"
+					:permissions="permissions"
+					:registrations="registrations"
 					:setlists="setlists"
+					:songs="songs"
 					:tags="tags"
 					:users="users"
-					:registrations="registrations"
-					:languages="languages"
-					:config="config"
-					:ready="ready"
 				></router-view>
 			</div>
 		</div>
@@ -243,32 +244,35 @@ export default {
 	data () {
 		return {
 			// db tables
-			songs: {},
+			config: {},
+			languages: {},
+			permissions: {},
+			registrations: {},
 			setlists: {},
+			songs: {},
 			tags: {},
 			users: {},
-			registrations: {},
-			languages: {},
-			config: {},
 			// loading indicators
 			ready: {
-				users: false,
-				registrations: false,
-				songs: false,
-				setlists: false,
-				tags: false,
-				languages: false,
 				config: false,
+				languages: false,
+				permissions: false,
+				registrations: false,
+				setlists: false,
+				songs: false,
+				tags: false,
+				users: false,
 			},
 			// db table listeners
 			listener: {
-				users: null,
-				registrations: null,
-				songs: null,
-				setlists: null,
-				tags: null,
+				config: null,
 				languages: null,
-				config: null
+				permissions: null,
+				registrations: null,
+				setlists: null,
+				songs: null,
+				tags: null,
+				users: null,
 			},
 			// modals
 			open: false,
@@ -352,7 +356,8 @@ export default {
 		// remove listeners for changes on each db table
 		unlisten () {
 			for (const table in this.listener) {
-				this.listener[table]();
+				let unsubscribe = this.listener[table];
+				unsubscribe();
 			}
 		},
 		// loads configuration without listener

--- a/src/modals/UserDelete.vue
+++ b/src/modals/UserDelete.vue
@@ -35,6 +35,9 @@ export default {
 		deleteUser () {
 			// delete approved user (living in users table) or unapproved user (living in registrations table)
 			this.$db.collection(this.approved ? 'users' : 'registrations').doc(this.userKey).delete().then(() => {
+				if (this.approved) {
+					this.$db.collection('permissions').doc(this.userKey).delete();
+				}
 				this.$emit('closed');
 				// toast success message
 				this.$notify({

--- a/src/views/Setlists.vue
+++ b/src/views/Setlists.vue
@@ -23,7 +23,7 @@
 			<div v-if="noSetlists" class="columns mt-2">
 				<!-- heading -->
 				<div class="column col-12">
-					<span v-if="user != '' && role != ''">{{ $t('text.noSetlistsAvailableSignedIn') }}</span>
+					<span v-if="user && role">{{ $t('text.noSetlistsAvailableSignedIn') }}</span>
 					<span v-else>{{ $t('text.noSetlistsAvailableSignedOut') }}</span>
 				</div>
 			</div>

--- a/src/views/Songs.vue
+++ b/src/views/Songs.vue
@@ -23,7 +23,7 @@
 			<div v-if="noSongs" class="columns mt-2">
 				<!-- heading -->
 				<div class="column col-12">
-					<span v-if="user != '' && role != ''">{{ $t('text.noSongsAvailableSignedIn') }}</span>
+					<span v-if="user && role">{{ $t('text.noSongsAvailableSignedIn') }}</span>
 					<span v-else>{{ $t('text.noSongsAvailableSignedOut') }}</span>
 				</div>
 			</div>


### PR DESCRIPTION
## Description of the Change

This moves the data about users permissions (the *role* field) from the users collections to a separate permissions collection. Firestore rules are updated accordingly. Only admins have writing access to the permissions collection.

## Benefits

Additional layer of security due to permissions data separated from users data.

## Applicable Issues

Closes #92 
