### PR TITLE
Create user as admin

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -333,10 +333,10 @@ export default {
 					if (userEntry.exists) {
 						this.auth.confirmed = true;
 						this.listen();
+						this.loading = false;
 					} else {
 						this.auth.confirmed = false;
 					}
-					this.loading = false;
 				}).catch(() => {
 					this.auth.confirmed = false;
 				});

--- a/src/App.vue
+++ b/src/App.vue
@@ -436,26 +436,24 @@ export default {
 				// load general app config
 				this.loadConfig();
 				// create registration for admin approval
-				this.$db.collection('registrations').doc(this.auth.user).set({ email: user.email, name: user.name })
-					.then(() => {
-						this.auth.userObject = firebase.auth().currentUser
-						this.auth.userObject.updateProfile({ displayName: user.name })
-						this.$notify({
-							title: this.$t('toast.signedUp'),
-							text: this.$t('toast.signedUpText', { name: user.name }),
-							type: 'primary'
-						});
-					}).catch((error) => this.throwError(error));
+				this.$db.collection('registrations').doc(this.auth.user).set({ email: user.email, name: user.name }).then(() => {
+					this.auth.userObject = firebase.auth().currentUser
+					this.auth.userObject.updateProfile({ displayName: user.name })
+					this.$notify({
+						title: this.$t('toast.signedUp'),
+						text: this.$t('toast.signedUpText', { name: user.name }),
+						type: 'primary'
+					});
+				}).catch((error) => this.throwError(error));
 				// send verification email
-				firebase.auth().currentUser.sendEmailVerification()
-					.then(() => {
-						// Verification email sent
-						this.$notify({
-							title:  this.$t('toast.verficationSent'),
-							text:  this.$t('toast.verficationSentText'),
-							type: 'primary'
-						});
-					}).catch((error) => this.throwError(error));
+				firebase.auth().currentUser.sendEmailVerification().then(() => {
+					// Verification email sent
+					this.$notify({
+						title:  this.$t('toast.verficationSent'),
+						text:  this.$t('toast.verficationSentText'),
+						type: 'primary'
+					});
+				}).catch((error) => this.throwError(error));
 			}).catch((error) => this.throwError(error));
 		},
 	},

--- a/src/App.vue
+++ b/src/App.vue
@@ -371,7 +371,7 @@ export default {
 					this.config.contact = doc.data();
 					this.ready.config = true;
 				}
-			}).catch(error => this.$notify({ title: error.code, text: error.message, type: 'error' }));
+			}).catch((error) => this.throwError(error));
 		},
 		resetSong () {
 			this.newSong = {
@@ -413,7 +413,7 @@ export default {
 					text: this.$t('toast.signedInText', { name: this.auth.userObject.displayName }),
 					type: 'primary'
 				});
-			}).catch((error) => this.$notify({ title: error.code, text: error.message, type: 'error' }));
+			}).catch((error) => this.throwError(error));
 		},
 		signOut () {
 			firebase.auth().signOut().then(() => {
@@ -427,7 +427,7 @@ export default {
 					text: this.$t('toast.signedOutText'),
 					type: 'primary'
 				});
-			}).catch((error) => this.$notify({ title: error.code, text: error.message, type: 'error' }));
+			}).catch((error) => this.throwError(error));
 		},
 		signUp (user) {
 			firebase.auth().createUserWithEmailAndPassword(user.email, user.password).then(() => {
@@ -445,7 +445,7 @@ export default {
 							text: this.$t('toast.signedUpText', { name: user.name }),
 							type: 'primary'
 						});
-					}).catch((error) => this.$notify({ title: error.code, text: error.message, type: 'error' }));
+					}).catch((error) => this.throwError(error));
 				// send verification email
 				firebase.auth().currentUser.sendEmailVerification()
 					.then(() => {
@@ -455,8 +455,8 @@ export default {
 							text:  this.$t('toast.verficationSentText'),
 							type: 'primary'
 						});
-					}).catch((error) => this.$notify({ title: error.code, text: error.message, type: 'error' }));
-			}).catch((error) => this.$notify({ title: error.code, text: error.message, type: 'error' }));
+					}).catch((error) => this.throwError(error));
+			}).catch((error) => this.throwError(error));
 		},
 	},
 	computed: {

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -539,15 +539,18 @@ a:active,
 	}
 }
 .form-input,
+.form-input:not(:placeholder-shown),
 .form-select,
 .form-select:not([multiple]):not([size]) {
 	width: 100%;
 
   .has-error &,
-  &.is-error {
+  &.is-error,
+	&:invalid {
     background-color: darken($error-color, 40%);
     border-color: $error-color;
     &:focus {
+			background: darken($error-color, 40%);
       box-shadow: 0 0 0 .2rem rgba($error-color, .2);
     }
   }

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -64,6 +64,12 @@ a, a:visited {
 a:focus, a:hover, a:active, a.active {
 	text-decoration: none;
 }
+hr {
+	border: 0;
+	height: 1px;
+	background: $border-color-dark;
+	margin: $unit-4 auto;
+}
 
 // icons
 .icon {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -306,6 +306,7 @@
     "tagSavedText": "Das Tag wurden erfolgreich gespeichert.",
     "tagUpdated": "Tag aktualisiert",
     "userAdded": "Benutzer hinzugefügt",
+    "userAddedText": "Der neue Benutzer wurde erfolgreich angelegt und eine E-Mail zur Bestätigung versandt.",
     "userDeleted": "Benutzer gelöscht",
     "userDeletedText": "Der Benutzer wurde erfolgreich entfernt.",
     "userSavedText": "Die Benutzerdaten wurden erfolgreich gespeichert.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -218,6 +218,7 @@
     "configureApp": "Allgemeine Anwendungsparameter verwalten",
     "confirmationSubject": "[SongDrive] Benutzerkonto aktiviert",
     "confirmationBody": "Hallo {0},\n\ndu wurdest soeben für die Nutzung von SongDrive freigeschaltet. Du kannst dich nun einloggen unter {1}\n\nKontaktiere uns gern, wenn du Fragen hast.\n\nDein SongDrive-Team\n\n",
+    "confirmWithAdminPassword": "Bitte gib zur Bestätigung dein Administrator-Passwort erneut ein",
     "createNewAccount": "Erstelle ein neues SongDrive Konto.",
     "customizeProfile": "Passe deine Profildaten an",
     "customizeUi": "Passe die Benutzeroberfläche an",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -218,6 +218,7 @@
     "configureApp": "Manage general app parameters",
     "confirmationSubject": "[SongDrive] Your account got activated",
     "confirmationBody": "Hi {0},\n\nYou were approved to use SongDrive just now. You can now log in under {1}\n\nIf you have any questions, please contact us!\n\nYour SongDrive-Team\n\n",
+    "confirmWithAdminPassword": "To confirm please enter your admin password again",
     "createNewAccount": "Create a new SongDrive account.",
     "customizeProfile": "Customize your profile data",
     "customizeUi": "Customize the user interface",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -306,6 +306,7 @@
     "tagSavedText": "Tag data was successfully saved.",
     "tagUpdated": "Tag updated",
     "userAdded": "User added",
+    "userAddedText": "The new user was successfully created and verification email was sent.",
     "userDeleted": "User deleted",
     "userDeletedText": "The user was successfully removed.",
     "userSavedText": "User data was successfully saved.",

--- a/src/main.js
+++ b/src/main.js
@@ -315,6 +315,17 @@ Vue.mixin({
 				text: error.message,
 				type: 'error'
 			});
+		},
+		// calculate example password
+		examplePassword: (length) => {
+			let pass = '', rdm62;
+			while (length--) {
+			 // Generate random integer between 0 and 61, 0|x works for Math.floor(x) in this case 
+			 rdm62 = 0 | Math.random() * 62; 
+			 // Map to ascii codes: 0-9 to 48-57 (0-9), 10-35 to 65-90 (A-Z), 36-61 to 97-122 (a-z)
+			 pass += String.fromCharCode(rdm62 + (rdm62 < 10 ? 48 : rdm62 < 36 ? 55 : 61)) 
+			}
+			return pass;
 		}
   }
 })

--- a/src/main.js
+++ b/src/main.js
@@ -307,6 +307,14 @@ Vue.mixin({
 			return userName
 				? userName.trim().split(' ', 2).reduce((p, c) => p + c.charAt(0), '').toUpperCase()
 				: ''
+		},
+		// toast error message
+		throwError: (error) => {
+			this.$notify({
+				title: error.code,
+				text: error.message,
+				type: 'error'
+			});
 		}
   }
 })

--- a/src/main.js
+++ b/src/main.js
@@ -310,7 +310,7 @@ Vue.mixin({
 		},
 		// toast error message
 		throwError: (error) => {
-			this.$notify({
+			Vue.notify({
 				title: error.code,
 				text: error.message,
 				type: 'error'

--- a/src/modals/LanguageDelete.vue
+++ b/src/modals/LanguageDelete.vue
@@ -40,15 +40,7 @@ export default {
 					text: this.$parent.$t('toast.languageDeletedText'),
 					type: 'primary'
 				});
-			}).catch((error) => {
-				this.$emit('closed');
-				// toast error message
-				this.$notify({
-					title: error.code,
-					text: error.message,
-					type: 'error'
-				});
-			});
+			}).catch((error) => this.throwError(error));
 		}
 	}
 }

--- a/src/modals/LanguageSet.vue
+++ b/src/modals/LanguageSet.vue
@@ -78,42 +78,28 @@ export default {
 					this.$db.collection('languages').doc(this.isocode).update({
 						label: this.language.label,
 					}).then(() => {
+						this.$emit('closed');
 						// language updated successfully!
 						this.$notify({
 							title: this.$parent.$t('toast.languageUpdated'),
 							text: this.$parent.$t('toast.languageSavedText'),
 							type: 'primary'
 						});
-					}).catch((error) => {
-						// an error occured on updating language
-						this.$notify({
-							title: error.code,
-							text: error.message,
-							type: 'error'
-						});
-					});
-					this.$emit('closed');
+					}).catch((error) => this.throwError(error));
 				}
 				// language doesn't exist yet
 				else {
 					this.$db.collection('languages').doc(this.isocode).set({
 						label: this.language.label,
 					}).then(() => {
+						this.$emit('closed');
 						// language added successfully
 						this.$notify({
 							title: this.$parent.$t('toast.languageAdded'),
 							text: this.$parent.$t('toast.languageSavedText'),
 							type: 'primary'
 						});
-					}).catch((error) => {
-						// an error occured on adding language
-						this.$notify({
-							title: error.code,
-							text: error.message,
-							type: 'error'
-						});
-					});
-					this.$emit('closed');
+					}).catch((error) => this.throwError(error));
 				}
 			}
 		}

--- a/src/modals/SetlistDelete.vue
+++ b/src/modals/SetlistDelete.vue
@@ -43,15 +43,7 @@ export default {
 					text: this.$parent.$t('toast.setlistDeletedText'),
 					type: 'primary'
 				});
-			}).catch((error) => {
-				this.$emit('closed');
-				// toast error message
-				this.$notify({
-					title: error.code,
-					text: error.message,
-					type: 'error'
-				});
-			})
+			}).catch((error) => this.throwError(error));
 		},
 	}
 }

--- a/src/modals/SetlistSet.vue
+++ b/src/modals/SetlistSet.vue
@@ -320,53 +320,50 @@ export default {
 				};
 				// new setlist should be created
 				if (!this.existing) {
-					this.$db.collection('setlists').doc(slug).set(processedSetlist)
-						.then(() => {
-							this.$emit('closed');
-							this.$emit('reset');
-							processedSetlist = {};
-							this.$router.push({ name: 'setlist-show', params: { id: slug }});
-							// toast success creation message
-							this.$notify({
-								title: this.$parent.$t('toast.setlistAdded'),
-								text: this.$parent.$t('toast.setlistSavedText'),
-								type: 'primary'
-							});
-						}).catch((error) => this.throwError(error));
+					this.$db.collection('setlists').doc(slug).set(processedSetlist).then(() => {
+						this.$emit('closed');
+						this.$emit('reset');
+						processedSetlist = {};
+						this.$router.push({ name: 'setlist-show', params: { id: slug }});
+						// toast success creation message
+						this.$notify({
+							title: this.$parent.$t('toast.setlistAdded'),
+							text: this.$parent.$t('toast.setlistSavedText'),
+							type: 'primary'
+						});
+					}).catch((error) => this.throwError(error));
 				}
 				// existing setlist should be updated
 				else {
 					// check if key remained (no title or date change)
 					if (this.setlistKey == slug) {
 						// just update the existing setlist
-						this.$db.collection('setlists').doc(this.setlistKey).update(processedSetlist)
-							.then(() => {
-								this.$emit('closed');
-								this.$emit('reset');
-								processedSetlist = {};
-								// toast success update message
-								this.$notify({
-									title: this.$parent.$t('toast.setlistUpdated'),
-									text: this.$parent.$t('toast.setlistSavedText'),
-									type: 'primary'
-								});
-							}).catch((error) => this.throwError(error));
+						this.$db.collection('setlists').doc(this.setlistKey).update(processedSetlist).then(() => {
+							this.$emit('closed');
+							this.$emit('reset');
+							processedSetlist = {};
+							// toast success update message
+							this.$notify({
+								title: this.$parent.$t('toast.setlistUpdated'),
+								text: this.$parent.$t('toast.setlistSavedText'),
+								type: 'primary'
+							});
+						}).catch((error) => this.throwError(error));
 					} else {
 						// update key by adding a new setlist and removing the old one
 						this.$db.collection('setlists').doc(this.setlistKey).delete();
-						this.$db.collection('setlists').doc(slug).set(processedSetlist)
-							.then(() => {
-								this.$emit('closed');
-								this.$emit('reset');
-								processedSetlist = {};
-								this.$router.push({ name: 'setlist-show', params: { id: slug }});
-								// toast success update message
-								this.$notify({
-									title: this.$parent.$t('toast.setlistUpdated'),
-									text: this.$parent.$t('toast.setlistSavedText'),
-									type: 'primary'
-								});
-							}).catch((error) => this.throwError(error));
+						this.$db.collection('setlists').doc(slug).set(processedSetlist).then(() => {
+							this.$emit('closed');
+							this.$emit('reset');
+							processedSetlist = {};
+							this.$router.push({ name: 'setlist-show', params: { id: slug }});
+							// toast success update message
+							this.$notify({
+								title: this.$parent.$t('toast.setlistUpdated'),
+								text: this.$parent.$t('toast.setlistSavedText'),
+								type: 'primary'
+							});
+						}).catch((error) => this.throwError(error));
 					}
 				}
 			}

--- a/src/modals/SetlistSet.vue
+++ b/src/modals/SetlistSet.vue
@@ -332,12 +332,7 @@ export default {
 								text: this.$parent.$t('toast.setlistSavedText'),
 								type: 'primary'
 							});
-						})
-						.catch((error) => {
-							this.$emit('closed');
-							// toast error on creation message
-							this.$notify({ title: error.code, text: error.message, type: 'error' });
-						})
+						}).catch((error) => this.throwError(error));
 				}
 				// existing setlist should be updated
 				else {
@@ -355,12 +350,7 @@ export default {
 									text: this.$parent.$t('toast.setlistSavedText'),
 									type: 'primary'
 								});
-							})
-							.catch((error) => {
-								this.$emit('closed');
-								// toast error on update message
-								this.$notify({ title: error.code, text: error.message, type: 'error' });
-							})
+							}).catch((error) => this.throwError(error));
 					} else {
 						// update key by adding a new setlist and removing the old one
 						this.$db.collection('setlists').doc(this.setlistKey).delete();
@@ -376,12 +366,7 @@ export default {
 									text: this.$parent.$t('toast.setlistSavedText'),
 									type: 'primary'
 								});
-							})
-							.catch((error) => {
-								this.$emit('closed');
-								// toast error on update message
-								this.$notify({ title: error.code, text: error.message, type: 'error' });
-							})
+							}).catch((error) => this.throwError(error));
 					}
 				}
 			}

--- a/src/modals/SignUp.vue
+++ b/src/modals/SignUp.vue
@@ -45,7 +45,7 @@
 						v-model="auth.password"
 						class="form-input mb-1"
 						:class="{ 'is-error': error.password.missing || error.password.mismatch || error.password.tooshort }"
-						:placeholder="$t('placeholder.examplePassword', { p: Math.random().toString(36).substr(2, 10) })"
+						:placeholder="$t('placeholder.examplePassword', { p: example.password })"
 					/>
 					<input
 						type="password"
@@ -87,6 +87,9 @@ export default {
 				email: '',
 				password: '',
 				repeat: '',
+			},
+			example: {
+				password: this.examplePassword(8)
 			},
 			error: {
 				name: false,

--- a/src/modals/SongDelete.vue
+++ b/src/modals/SongDelete.vue
@@ -43,15 +43,7 @@ export default {
 					text: this.$parent.$t('toast.songDeletedText'),
 					type: 'primary'
 				});
-			}).catch((error) => {
-				this.$emit('closed');
-				// toast error message
-				this.$notify({
-					title: error.code,
-					text: error.message,
-					type: 'error'
-				});
-			})
+			}).catch((error) => this.throwError(error));
 		},
 	}
 }

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -453,16 +453,7 @@ export default {
 								text: this.$parent.$t('toast.songSavedText'),
 								type: 'primary'
 							});
-						})
-						.catch((error) => {
-							this.$emit('closed');
-							// toast error on creation message
-							this.$notify({
-								title: error.code,
-								text: error.message,
-								type: 'error'
-							});
-						});
+						}).catch((error) => this.throwError(error));
 				}
 				// existing song should be updated
 				else {
@@ -480,16 +471,7 @@ export default {
 									text: this.$parent.$t('toast.songSavedText'),
 									type: 'primary'
 								});
-							})
-							.catch((error) => {
-								this.$emit('closed');
-								// toast error on creation message
-								this.$notify({
-									title: error.code,
-									text: error.message,
-									type: 'error'
-								});
-							});
+							}).catch((error) => this.throwError(error));
 					} else {
 						// update key by adding a new song and removing the old one
 						this.$db.collection('songs').doc(this.id).delete();
@@ -505,16 +487,7 @@ export default {
 									text: this.$parent.$t('toast.songSavedText'),
 									type: 'primary'
 								});
-							})
-							.catch((error) => {
-								this.$emit('closed');
-								// toast error on creation message
-								this.$notify({
-									title: error.code,
-									text: error.message,
-									type: 'error'
-								});
-							});
+							}).catch((error) => this.throwError(error));
 					}
 				}
 			}

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -441,53 +441,50 @@ export default {
 				};
 				// new song should be created
 				if (!this.existing) {
-					this.$db.collection('songs').doc(slug).set(processedSong)
-						.then(() => {
-							this.$emit('closed');
-							this.$emit('reset');
-							processedSong = {};
-							this.$router.push({ name: 'song-show', params: { id: slug }});
-							// toast success creation message
-							this.$notify({
-								title: this.$parent.$t('toast.songAdded'),
-								text: this.$parent.$t('toast.songSavedText'),
-								type: 'primary'
-							});
-						}).catch((error) => this.throwError(error));
+					this.$db.collection('songs').doc(slug).set(processedSong).then(() => {
+						this.$emit('closed');
+						this.$emit('reset');
+						processedSong = {};
+						this.$router.push({ name: 'song-show', params: { id: slug }});
+						// toast success creation message
+						this.$notify({
+							title: this.$parent.$t('toast.songAdded'),
+							text: this.$parent.$t('toast.songSavedText'),
+							type: 'primary'
+						});
+					}).catch((error) => this.throwError(error));
 				}
 				// existing song should be updated
 				else {
 					// check if key remained (no title or language changes)
 					if (this.id == slug) {
 						// just update the existing setlist
-						this.$db.collection('songs').doc(this.id).update(processedSong)
-							.then(() => {
-								this.$emit('closed');
-								this.$emit('reset');
-								processedSong = {};
-								// toast success update message
-								this.$notify({
-									title: this.$parent.$t('toast.songUpdated'),
-									text: this.$parent.$t('toast.songSavedText'),
-									type: 'primary'
-								});
-							}).catch((error) => this.throwError(error));
+						this.$db.collection('songs').doc(this.id).update(processedSong).then(() => {
+							this.$emit('closed');
+							this.$emit('reset');
+							processedSong = {};
+							// toast success update message
+							this.$notify({
+								title: this.$parent.$t('toast.songUpdated'),
+								text: this.$parent.$t('toast.songSavedText'),
+								type: 'primary'
+							});
+						}).catch((error) => this.throwError(error));
 					} else {
 						// update key by adding a new song and removing the old one
 						this.$db.collection('songs').doc(this.id).delete();
-						this.$db.collection('songs').doc(slug).set(processedSong)
-							.then(() => {
-								this.$emit('closed');
-								this.$emit('reset');
-								processedSong = {};
-								this.$router.push({ name: 'song-show', params: { id: slug }});
-								// toast success update message
-								this.$notify({
-									title: this.$parent.$t('toast.songUpdated'),
-									text: this.$parent.$t('toast.songSavedText'),
-									type: 'primary'
-								});
-							}).catch((error) => this.throwError(error));
+						this.$db.collection('songs').doc(slug).set(processedSong).then(() => {
+							this.$emit('closed');
+							this.$emit('reset');
+							processedSong = {};
+							this.$router.push({ name: 'song-show', params: { id: slug }});
+							// toast success update message
+							this.$notify({
+								title: this.$parent.$t('toast.songUpdated'),
+								text: this.$parent.$t('toast.songSavedText'),
+								type: 'primary'
+							});
+						}).catch((error) => this.throwError(error));
 					}
 				}
 			}

--- a/src/modals/TagSet.vue
+++ b/src/modals/TagSet.vue
@@ -81,21 +81,14 @@ export default {
 						key: this.key,
 						...this.languages
 					}).then(() => {
+						this.$emit('closed');
 						// tag updated successfully!
 						this.$notify({
 							title: this.$parent.$t('toast.tagUpdated'),
 							text: this.$parent.$t('toast.tagSavedText'),
 							type: 'primary'
 						});
-					}).catch((error) => {
-						// an error occured on updating tag
-						this.$notify({
-							title: error.code,
-							text: error.message,
-							type: 'error'
-						});
-					});
-					this.$emit('closed');
+					}).catch((error) => this.throwError(error));
 				}
 				// tag doesn't exist yet
 				else {
@@ -103,21 +96,14 @@ export default {
 						key: this.key,
 						...this.languages
 					}).then(() => {
+						this.$emit('closed');
 						// tag added successfully
 						this.$notify({
 							title: this.$parent.$t('toast.tagAdded'),
 							text: this.$parent.$t('toast.tagSavedText'),
 							type: 'primary'
 						});
-					}).catch((error) => {
-						// an error occured on adding tag
-						this.$notify({
-							title: error.code,
-							text: error.message,
-							type: 'error'
-						});
-					});
-					this.$emit('closed');
+					}).catch((error) => this.throwError(error));
 				}
 			}
 		}

--- a/src/modals/UserDelete.vue
+++ b/src/modals/UserDelete.vue
@@ -45,15 +45,7 @@ export default {
 					text: this.$parent.$t('toast.userDeletedText'),
 					type: 'primary'
 				});
-			}).catch((error) => {
-				this.$emit('closed');
-				// toast error message
-				this.$notify({
-					title: error.code,
-					text: error.message,
-					type: 'error'
-				});
-			});
+			}).catch((error) => this.throwError(error));
 		}
 	}
 }

--- a/src/modals/UserSet.vue
+++ b/src/modals/UserSet.vue
@@ -91,6 +91,7 @@ export default {
 							name: this.user.name,
 							email: this.user.email,
 						}).then(() => {
+							this.$emit('closed');
 							this.$notify({
 								title: this.$parent.$t('toast.userUpdated'),
 								text: this.$parent.$t('toast.userSavedText'),
@@ -98,7 +99,6 @@ export default {
 							});
 						}).catch((error) => this.throwError(error));
 					}).catch((error) => this.throwError(error));
-					this.$emit('closed');
 				}
 				// user is not yet confirmed
 				else {
@@ -109,6 +109,7 @@ export default {
 						// user added successfully, now add permission and delete temporary registration
 						this.$db.collection('permissions').doc(this.userKey).set(this.permission).then(() => {
 							this.$db.collection('registrations').doc(this.userKey).delete().then(() => {
+								this.$emit('closed');
 								this.$notify({
 									title: this.$parent.$t('toast.userAdded'),
 									text: this.$parent.$t('toast.userSavedText'),
@@ -117,7 +118,6 @@ export default {
 							}).catch((error) => this.throwError(error));
 						}).catch((error) => this.throwError(error));
 					}).catch((error) => this.throwError(error));
-					this.$emit('closed');
 				}
 			}
 		}

--- a/src/modals/UserSet.vue
+++ b/src/modals/UserSet.vue
@@ -56,10 +56,10 @@
 						<option v-for="(r, k) in userRoles()" :key="k" :value="k">{{ $t('role.' + k) }}</option>
 					</select>
 				</div>
-				<hr />
 				<!-- admin password confirmation -->
 				<div v-if="state=='new'">
-					<label class="form-label" for="adminpassword">Bitte gibt zur Bestätigung dein eigenes Passwort erneut ein: <span class="text-error">*</span></label>
+					<hr />
+					<label class="form-label" for="adminpassword">{{ $t('text.confirmWithAdminPassword') }} <span class="text-error">*</span></label>
 					<input
 						id="adminpassword"
 						type="password"

--- a/src/modals/UserSet.vue
+++ b/src/modals/UserSet.vue
@@ -35,7 +35,12 @@
 					<p v-if="error.email" class="form-input-hint">{{ $t('error.requiredEmail') }}</p>
 					<!-- password -->
 					<div v-if="state=='new'">
-						<label class="form-label" for="password">{{ $t('field.password') }} <span class="text-error">*</span></label>
+						<label class="form-label" for="password">
+							{{ $t('field.password') }} <span class="text-error">*</span>
+							<span class="float-right" :class="{ 'text-error': user.password.length < 8 }">
+								{{ user.password.length }}<span v-if="user.password.length < 8"> / 8</span>
+							</span>
+						</label>
 						<input
 							id="password"
 							type="password"

--- a/src/modals/UserSet.vue
+++ b/src/modals/UserSet.vue
@@ -178,6 +178,7 @@ export default {
 				}
 				// user doesn't exist
 				if (this.state == 'new') {
+					this.$emit('started');
 					const email = firebase.auth().currentUser.email;
 					// create firebase user first
 					firebase.auth().createUserWithEmailAndPassword(this.user.email, this.user.password).then(() => {

--- a/src/modals/UserSet.vue
+++ b/src/modals/UserSet.vue
@@ -42,7 +42,7 @@
 							v-model="user.password"
 							class="form-input mb-1"
 							:class="{ 'is-error': error.password.missing || error.password.tooshort }"
-							:placeholder="$t('placeholder.examplePassword', { p: Math.random().toString(36).substr(2, 10) })"
+							:placeholder="$t('placeholder.examplePassword', { p: example.password })"
 						/>
 						<p v-if="error.password.missing || error.password.tooshort" class="form-input-hint">
 							<span v-if="error.password.missing">{{ $t('error.requiredPassword') }}</span>
@@ -103,6 +103,9 @@ export default {
 			},
 			admin: {
 				password: ''
+			},
+			example: {
+				password: this.examplePassword(8)
 			},
 			error: {
 				name: false,

--- a/src/modals/UserSet.vue
+++ b/src/modals/UserSet.vue
@@ -120,14 +120,6 @@ export default {
 					this.$emit('closed');
 				}
 			}
-		},
-		// toast error message
-		throwError (error) {
-			this.$notify({
-				title: error.code,
-				text: error.message,
-				type: 'error'
-			});
 		}
 	},
 	computed: {

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -483,13 +483,7 @@ export default {
 					text: this.$t('toast.setlistFormatCopiedText', {format: label}),
 					type: 'primary'
 				});
-			}, (error) => {
-				this.$notify({
-					title: this.$t('toast.failedToCopy'),
-					text: error,
-					type: 'error'
-				});
-			});
+			}, (error) => this.throwError(error));
 		},
 		exportPdf (mode) {
 			var content = mode == 'sheets' ? this.getPdfSongsheets() : this.getPdfSetlist();

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -395,14 +395,16 @@ export default {
 		reorder ({oldIndex, newIndex}) {
 			const movedItem = this.setlist.songs.splice(oldIndex, 1)[0];
 			this.setlist.songs.splice(newIndex, 0, movedItem);
-			this.$db.collection('setlists').doc(this.$route.params.id).set({songs: this.setlist.songs}, { merge: true })
-				.then(() => {
-					this.$notify({
-						title: this.$t('toast.songOrderUpdated'),
-						text: this.$t('toast.setlistSavedText'),
-						type: 'primary'
-					});
+			this.$db.collection('setlists').doc(this.$route.params.id).set(
+				{ songs: this.setlist.songs },
+				{ merge: true }
+			).then(() => {
+				this.$notify({
+					title: this.$t('toast.songOrderUpdated'),
+					text: this.$t('toast.setlistSavedText'),
+					type: 'primary'
 				});
+			}).catch((error) => this.throwError(error));;
 		},
 		tuneUp (song, songPosition) {
 			let songs = this.setlist.songs;
@@ -441,7 +443,7 @@ export default {
 					text: this.$t('toast.setlistStatusSavedText'),
 					type: 'primary'
 				});
-			});
+			}).catch((error) => this.throwError(error));;
 		},
 		updatePosition (position) {
 			// update setlist's position if sync enabled

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -111,7 +111,13 @@
 								<button
 									class="btn btn-secondary tooltip px-3 m-3"
 									:data-tooltip="$t('modal.addUser')"
-									@click="active.user={ name: '', email: '' }; active.role='reader'; active.key=''; active.existing=false; modal.userset=true"
+									@click="
+										active.userId = '';
+										active.user = { name: '', email: '', password: '' };
+										active.role = 'reader';
+										active.state = 'new';
+										modal.userset = true;
+									"
 								>
 									<ion-icon name="add-outline"></ion-icon>
 								</button>
@@ -151,7 +157,13 @@
 									<button
 										class="btn btn-link btn-action tooltip"
 										:data-tooltip="$t('modal.editUser')"
-										@click.prevent="active.user=u; active.role=permissions[k].role; active.key=k; active.existing=true; modal.userset=true"
+										@click.prevent="
+											active.userId = k;
+											active.user = u;
+											active.role = permissions[k].role;
+											active.state = 'confirmed';
+											modal.userset = true;
+										"
 									>
 										<ion-icon name="create-outline"></ion-icon>
 									</button>
@@ -195,7 +207,13 @@
 									<button
 										class="btn btn-link btn-action tooltip"
 										:data-tooltip="$t('tooltip.approveUser')"
-										@click.prevent="active.user=r; active.role='reader'; active.key=k; active.existing=false; modal.userset=true"
+										@click.prevent="
+											active.userId = k;
+											active.user = r;
+											active.role = 'reader';
+											active.state = 'registered';
+											modal.userset = true;
+										"
 									>
 										<ion-icon name="person-add-outline"></ion-icon>
 									</button>
@@ -360,10 +378,10 @@
 			<UserSet
 				v-if="modal.userset"
 				:active="modal.userset"
-				:existing="active.existing"
+				:userId="active.userId"
 				:initialUser="active.user"
 				:role="active.role"
-				:userKey="active.key"
+				:state="active.state"
 				@closed="modal.userset = false"
 			/>
 			<!-- modal: delete user -->
@@ -470,8 +488,10 @@ export default {
 				importdata: false,
 			},
 			active: {
+				userId: '',
 				user: {},
 				role: '',
+				state: '',
 				language: {},
 				tag: {},
 				key: '',

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -103,10 +103,19 @@
 				<!-- user administration -->
 				<div class="column col-4 col-xl-6 col-md-12 mt-4">
 					<div class="panel">
-						<div class="panel-header text-center">
+						<div class="panel-header text-center pos-relative">
 							<ion-icon name="people-outline" class="icon-2x"></ion-icon>
 							<div class="panel-title h5 mt-1">{{ Object.keys(users).length }} {{ $t('widget.users') }}</div>
 							<div class="panel-subtitle text-gray">{{ $t('text.manageConfirmedUsers') }}</div>
+							<div class="pos-absolute-tr">
+								<button
+									class="btn btn-secondary tooltip px-3 m-3"
+									:data-tooltip="$t('modal.addUser')"
+									@click="active.user={ name: '', email: '' }; active.role='reader'; active.key=''; active.existing=false; modal.userset=true"
+								>
+									<ion-icon name="add-outline"></ion-icon>
+								</button>
+							</div>
 						</div>
 						<div class="panel-body">
 							<div
@@ -536,14 +545,6 @@ export default {
 				type: 'primary'
 			});
 		},
-		// toast error message
-		throwError (error) {
-			this.$notify({
-				title: error.code,
-				text: error.message,
-				type: 'error'
-			});
-		}
 	},
 	computed: {
 		uiLanguages () {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -94,6 +94,7 @@
 					</div>
 				</div>
 			</div>
+			<!-- administration area -->
 			<div v-if="ready.users && ready.permissions && user && userObject && role > 1" class="columns mt-4 pt-4">
 				<div class="column col-12">
 					<h2>
@@ -362,18 +363,6 @@
 					</div>
 				</div>
 			</div>
-			<!-- not logged in -->
-			<div v-if="ready.users && !user" class="columns">
-				<div class="column col-">
-					<div class="empty">
-						<div class="empty-icon">
-							<ion-icon name="eye-off-outline" class="icon-4x"></ion-icon>
-						</div>
-						<p class="empty-title h5">{{ $t('text.pageNotAvailable') }}</p>
-						<p class="empty-subtitle">{{ $t('text.signInForAccess') }}</p>
-					</div>
-				</div>
-			</div>
 			<!-- modal: set user -->
 			<UserSet
 				v-if="modal.userset"
@@ -382,6 +371,7 @@
 				:initialUser="active.user"
 				:role="active.role"
 				:state="active.state"
+				@started="$emit('started')"
 				@closed="modal.userset = false"
 			/>
 			<!-- modal: delete user -->


### PR DESCRIPTION
## Description of the Change

This adds the ability for admin users to create new users directly from the settings page. To actually add the new user, the admin needs to provide his password again for re-authentication. The new user will automatically receive a verification mail to his email address.

![image](https://user-images.githubusercontent.com/5441654/146459788-7790ce39-987d-4212-a2e9-3f79b09db7cc.png)
![image](https://user-images.githubusercontent.com/5441654/146459831-b4f9f4a3-9871-4dd5-a379-20c12cff836b.png)

## Benefits

Admins now can create users themselves without asking the users to register.

## Applicable Issues

Implements #96 
