### PR TITLE
Login screen improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# SongDrive
+<img width="352" alt="songdrive_logo_word" src="https://user-images.githubusercontent.com/5441654/147848659-8cbc8ac6-d7d8-4c56-a36d-ce904da2bd5a.png">
 
-[![Release](https://img.shields.io/github/v/tag/devmount/SongDrive.svg?label=release&color=88b544&style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsSAAALEgHS3X78AAAATklEQVQ4jWP8//8/AyWAiSLd1DCABZfEnnsVKH5zUepgpIkLKA5EnF7o3OaKYnK5125GbN4aJF7A5jRsXsAmNki8QKxzB6cXKHMBAwMDAFesMxVwNRpMAAAAAElFTkSuQmCC)](https://github.com/devmount/SongDrive/releases)
+[![Release](https://img.shields.io/github/v/tag/devmount/SongDrive.svg?label=release&color=88b544&style=flat-square)](https://github.com/devmount/SongDrive/releases)
 [![Last Updated](https://img.shields.io/github/last-commit/devmount/SongDrive?label=updated&color=88b544&style=flat-square)](https://github.com/devmount/SongDrive/commits/main)
 [![CodeQL Analysis](https://img.shields.io/github/workflow/status/devmount/SongDrive/CodeQL?label=CodeQL&logo=github&color=88b544&style=flat-square)](https://github.com/devmount/SongDrive/actions/workflows/codeql-analysis.yml)
 [![License](https://img.shields.io/badge/license-MIT-88b544.svg?style=flat-square)](./LICENSE)
 [![Contribution Guidlines](https://img.shields.io/badge/contributions-welcome-88b544.svg?style=flat-square)](./.github/CONTRIBUTING.md)
 
-A song management web application to store, synchronize and present songs and setlists, based on [Vue.js](//vuejs.org/), [Firebase](//firebase.google.com/) and [Spectre.css](//github.com/picturepan2/spectre). Head over to the docs ([EN](https://github.com/devmount/SongDrive/blob/main/src/docs/docs.en.md), [DE](https://github.com/devmount/SongDrive/blob/main/src/docs/docs.en.md)) for more information how to get started with SongDrive.
-
-> **Note**  
-> SongDrive v1.x is currently in beta, if you are looking for SongDrive v0.x, you can download the final release v0.2.10 [here](https://github.com/devmount/SongDrive/releases/tag/v0.2.10).
+A song management web application to store, synchronize and present songs and setlists, based on [Vue.js](//vuejs.org/), [Firebase](//firebase.google.com/) and [Spectre.css](//github.com/picturepan2/spectre). Head over to the docs ([EN](https://github.com/devmount/SongDrive/blob/main/src/docs/docs.en.md), [DE](https://github.com/devmount/SongDrive/blob/main/src/docs/docs.en.md)) for more information about SongDrive and how to get started.
 
 ## Preview
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,8 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /index.html [L]
+</IfModule>

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,10 +14,8 @@
 			<div id="sidebar-id" class="off-canvas-sidebar" :class="{ active: open }">
 				<div class="sidebar-wrapper">
 					<div class="brand text-center mt-2">
-						<router-link to="/" class="logo">
-							<img src="./assets/logo.svg" alt="SongDrive Song Management Tool" />
-							<h1>{{ $t('app.name') }}</h1>
-							<div class="text-gray text-small text-right mr-5 pr-1">v{{ $version }} BETA</div>
+						<router-link to="/">
+							<Logo />
 						</router-link>
 					</div>
 					<ul class="menu text-uppercase">
@@ -240,6 +238,7 @@
 
 <script>
 // get components
+import Logo from '@/partials/Logo';
 import Login from '@/partials/Login';
 import SignUp from '@/modals/SignUp';
 import PasswordReset from '@/modals/PasswordReset';
@@ -256,6 +255,7 @@ import { collection, onSnapshot } from "firebase/firestore";
 export default {
 	name: 'app',
 	components: {
+		Logo,
 		Login,
 		SignUp,
 		PasswordReset,

--- a/src/App.vue
+++ b/src/App.vue
@@ -371,6 +371,7 @@ export default {
 			}
 			this.auth.ready = true;
 		});
+		this.auth.confirmed = false;
 	},
 	methods: {
 		// add listeners for changes on each db table

--- a/src/App.vue
+++ b/src/App.vue
@@ -85,7 +85,7 @@
 							</router-link>
 						</li>
 						<li class="menu-item">
-							<router-link to="/settings" class="py-2" @click.native="open = false">
+							<router-link to="/settings" class="py-2" :class="{ badge: registrationsExist && userRoles()[permissions[auth.user].role] > 3 }" @click.native="open = false">
 								<ion-icon name="options-outline" class="mr-2"></ion-icon> {{ $t('page.settings') }}
 							</router-link>
 						</li>
@@ -521,6 +521,10 @@ export default {
 		userName () {
 			return this.ready.users ? this.users[this.auth.user].name : '';
 		},
+		// check if at least one registration exists
+		registrationsExist () {
+			return Object.keys(this.registrations).length > 0;
+		}
 	},
 }
 </script>

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -988,26 +988,6 @@ a {
 // branding
 .brand {
 	padding: 1em 1em 0 1em;
-
-	.logo {
-		padding: .3em 0;
-		text-decoration: none;
-
-		img {
-			display: inline-block;
-			width: 32px;
-		}
-		h1 {
-			display: inline-block;
-			font-size: 1.1rem;
-			font-weight: 400;
-			letter-spacing: 2px;
-			line-height: 1.6rem;
-			margin-bottom: 0;
-			margin-left: .5rem;
-			margin-right: .5rem;
-		}
-	}
 }
 
 // sidebar menu

--- a/src/partials/Login.vue
+++ b/src/partials/Login.vue
@@ -1,9 +1,8 @@
 <template>
 	<div class="login">
 		<!-- heading -->
-		<div class="column col-12 text-center">
-			<img class="logo" src="@/assets/logo.svg" alt="SongDrive Song Management Tool" />
-			<h2 class="text-primary weight-normal mt-4">{{ $t('app.name') }}</h2>
+		<div class="column col-12">
+			<Logo class="featured hide-version" />
 		</div>
 		<!-- login -->
 		<div>
@@ -46,8 +45,14 @@
 </template>
 
 <script>
+// get components
+import Logo from '@/partials/Logo';
+
 export default {
 	name: 'login',
+	components: {
+		Logo
+	},
 	data () {
 		return {
 			email: '',
@@ -61,16 +66,10 @@ export default {
 .login {
 	display: flex;
 	flex-direction: column;
-	gap: 3rem;
+	gap: 2.5rem;
 	justify-content: center;
 	align-items: center;
 	height: 100vh;
-
-	.logo {
-		margin: 0 auto;
-		max-width: 150px;
-		width: 100%;
-	}
 
 	.panel {
 		height: auto;

--- a/src/partials/Logo.vue
+++ b/src/partials/Logo.vue
@@ -1,0 +1,52 @@
+<template>
+	<div class="logo">
+		<img src="../assets/logo.svg" alt="SongDrive Song Management Tool" />
+		<h1>{{ $t('app.name') }}</h1>
+		<div class="version text-gray text-small text-right mr-5">v{{ $version }} BETA</div>
+	</div>
+</template>
+
+<style lang="scss">
+.logo {
+	padding: .3em 0;
+	text-decoration: none;
+	cursor: default;
+	text-align: center;
+
+	img {
+		display: inline-block;
+		width: 32px;
+	}
+	h1 {
+		color: #88b544;
+		display: inline-block;
+		font-size: 1.1rem;
+		font-weight: 400;
+		letter-spacing: 2px;
+		line-height: 1.6rem;
+		margin-bottom: 0;
+		margin-left: .5rem;
+	}
+}
+
+.logo.featured {
+	margin: 0 auto;
+	max-width: 300px;
+	width: 100%;
+
+	img {
+		width: 48px;
+	}
+	h1 {
+		font-size: 1.75rem;
+	}
+}
+
+.logo.hide-version .version {
+	display: none;
+}
+
+a .logo {
+	cursor: pointer;
+}
+</style>

--- a/src/partials/UserUnconfirmed.vue
+++ b/src/partials/UserUnconfirmed.vue
@@ -1,9 +1,8 @@
 <template>
 	<div class="user-unconfirmed">
 		<!-- heading -->
-		<div class="column col-12 text-center">
-			<img class="logo" src="@/assets/logo.svg" alt="SongDrive Song Management Tool" />
-			<h2 class="text-primary weight-normal mt-4">{{ $t('app.name') }}</h2>
+		<div class="column col-12">
+			<Logo class="featured hide-version" />
 		</div>
 		<!-- unconfirmed message -->
 		<div class="message">
@@ -18,8 +17,14 @@
 </template>
 
 <script>
+// get components
+import Logo from '@/partials/Logo';
+
 export default {
 	name: 'user-unconfirmed',
+	components: {
+		Logo
+	},
 	props: ['ready', 'config']
 }
 </script>
@@ -28,16 +33,11 @@ export default {
 .user-unconfirmed {
 	display: flex;
 	flex-direction: column;
-	gap: 2rem;
+	gap: 2.5rem;
 	justify-content: center;
 	align-items: center;
 	height: 100vh;
 
-	.logo {
-		margin: 0 auto;
-		max-width: 150px;
-		width: 100%;
-	}
 	.message {
 		max-width: 400px;
 

--- a/src/partials/UserUnverified.vue
+++ b/src/partials/UserUnverified.vue
@@ -1,9 +1,8 @@
 <template>
 	<div class="user-unverified">
 		<!-- heading -->
-		<div class="column col-12 text-center">
-			<img class="logo" src="@/assets/logo.svg" alt="SongDrive Song Management Tool" />
-			<h2 class="text-primary weight-normal mt-4">{{ $t('app.name') }}</h2>
+		<div class="column col-12">
+			<Logo class="featured hide-version" />
 		</div>
 		<!-- unverified message -->
 		<div class="message">
@@ -24,8 +23,14 @@
 </template>
 
 <script>
+// get components
+import Logo from '@/partials/Logo';
+
 export default {
 	name: 'user-unverified',
+	components: {
+		Logo
+	},
 	props: ['ready', 'config'],
 	data () {
 		return {
@@ -45,16 +50,11 @@ export default {
 .user-unverified {
 	display: flex;
 	flex-direction: column;
-	gap: 2rem;
+	gap: 2.5rem;
 	justify-content: center;
 	align-items: center;
 	height: 100vh;
 
-	.logo {
-		margin: 0 auto;
-		max-width: 150px;
-		width: 100%;
-	}
 	.message {
 		max-width: 400px;
 


### PR DESCRIPTION
## Description of the Change

This changes unifies the SongDrive logo. It's now displayed the same in the upper left corner of the app, on the login view and on the unconfirmed / unverified views and in the README.

![image](https://user-images.githubusercontent.com/5441654/147848766-95f6f8b3-2c2d-48d1-81bb-1da59b848023.png)

Also the `.htaccess` file for routing on Apache webservers is now included and a bug showing the loading screen beneath the login view was fixed.

## Benefits

Logo UI is now more convenient.

## Applicable Issues

None.
