### PR TITLE
Fix reload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -371,7 +371,6 @@ export default {
 			}
 			this.auth.ready = true;
 		});
-		this.auth.confirmed = false;
 	},
 	methods: {
 		// add listeners for changes on each db table

--- a/src/modals/EmailChange.vue
+++ b/src/modals/EmailChange.vue
@@ -105,10 +105,10 @@ export default {
 				);
 				user.reauthenticateWithCredential(credential).then(() => {
 					// successfully reauthenticated, now update email address ...
-					user.updateEmail(this.user.email).then(() => {
-						this.$db.collection('users').doc(user.uid).update({
-							email: this.user.email,
-						}).then(() => {
+					this.$db.collection('users').doc(user.uid).update({
+						email: this.user.email,
+					}).then(() => {
+						user.updateEmail(this.user.email).then(() => {
 							// ... and send verification email
 							user.sendEmailVerification().then(() => {
 								this.$emit('closed');


### PR DESCRIPTION
## Description of the Change

This change contains two fixes:

- On reloading the page when logged in, the short flash of "Waiting for approval" is no longer shown
- The error message "missing permission" when change the accounts email address is now no longer shown

## Benefits

Better UX

## Applicable Issues

None