### PR TITLE
Song content placeholder

### DIFF
--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -203,6 +203,7 @@
 										class="form-input text-pre"
 										v-model="song.content"
 										:highlight="highlighter"
+										:placeholder="$t('placeholder.exampleSongContent')"
 									></prism-editor>
 									<!-- :placeholder="$t('placeholder.exampleSongContent')" -->
 									<p v-if="error.content" class="form-input-hint">{{ $t('error.requiredContent') }}</p>


### PR DESCRIPTION
## Description of the Change

This enables the placeholder for the textarea of song content with an example song again, as it was implemented earlier (before the song syntax highlighter).

## Benefits

Improved UX as the user always has a visual reminder of the song syntax.

## Applicable Issues

#73 is related
