### PR TITLE
Remove vertical scrollbars when presenting

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -176,6 +176,10 @@ ion-icon {
 	right: 0;
 }
 
+.o-hidden {
+	overflow: hidden;
+}
+
 // colors and text
 .bg-primary-dark {
 	background-color: $bg-color-dark;

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -628,6 +628,16 @@ export default {
 			}
 			return sheets;
 		}
+	},
+	watch: {
+		'modal.present': (newValue) => {
+			// remove scroll bar when in presentation moden
+			if (newValue) {
+				document.body.classList.add('o-hidden');
+			} else {
+				document.body.classList.remove('o-hidden');
+			}
+		}
 	}
 }
 </script>

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -537,6 +537,14 @@ export default {
 			if (this.songKey && this.song) {
 				this.tuning = this.urlKeyDiff();
 			}
+		},
+		'modal.present': (newValue) => {
+			// remove scroll bar when in presentation moden
+			if (newValue) {
+				document.body.classList.add('o-hidden');
+			} else {
+				document.body.classList.remove('o-hidden');
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description of the Change

This change removes vertical scrollbars when presenting songs or setlists. Scrollbars will be restored, when presentation is quit.

## Benefits

A little more horizontal space for presentation content, if scrollbars were shown.

## Applicable Issues

None
