### PR TITLE
Handle song slug changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -189,6 +189,7 @@
 			:initialSong="newSong"
 			songKey=""
 			:songs="songs"
+			:setlists="setlists"
 			:tags="tags"
 			:languages="languages"
 			:ready="ready"

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -245,6 +245,7 @@
 				:initialSong="song"
 				:id="songId"
 				:songs="songs"
+				:setlists="setlists"
 				:tags="tags"
 				:languages="languages"
 				:ready="ready"
@@ -292,7 +293,7 @@ pdfMake.fonts = {
 
 export default {
 	name: 'song-show',
-	props: ['songs', 'tags', 'languages', 'user', 'role', 'ready'],
+	props: ['songs', 'setlists', 'tags', 'languages', 'user', 'role', 'ready'],
 	components: {
 		SongContent,
 		SongSet,

--- a/src/views/Songs.vue
+++ b/src/views/Songs.vue
@@ -216,6 +216,7 @@
 				:initialSong="active.song"
 				:songKey="active.key"
 				:songs="songs"
+				:setlists="setlists"
 				:tags="tags"
 				:languages="languages"
 				:ready="ready"
@@ -239,7 +240,7 @@ import SongDelete from '@/modals/SongDelete';
 
 export default {
 	name: 'songs',
-	props: ['songs', 'tags', 'languages', 'user', 'role', 'ready'],
+	props: ['songs', 'setlists', 'tags', 'languages', 'user', 'role', 'ready'],
 	components: {
 		SongSet,
 		SongDelete,


### PR DESCRIPTION
## Description of the Change

This change persists song slug changes (when modifying song title) to all references to songs:

- songs field of setlists
- translations field of songs

## Benefits

Song titles can now be changes without throwing errors in setlists or translations of this song afterwards.

## Applicable Issues

Closes #105 
