### PR TITLE
Improve translation assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ This is how the SongDrive Dashboard currently looks like.
 - UI supports multiple languages (currently: EN, DE)
 - Export and Import of complete SongDrive data
 
-## Installation
+## Installation for developers
 
-1. Get all files
+1. Get all files from repository
 
     ```bash
     git clone https://github.com/devmount/SongDrive

--- a/src/main.js
+++ b/src/main.js
@@ -328,6 +328,26 @@ Vue.mixin({
 			 pass += String.fromCharCode(rdm62 + (rdm62 < 10 ? 48 : rdm62 < 36 ? 55 : 61)) 
 			}
 			return pass;
+		},
+		// make a given string url friendly
+		urlify: (s) => {
+			return s.trim().toLowerCase()
+				.replace(/\s/g, '-')
+				.replace(/\//g, '-')
+				.replace(/\_/g, '-')
+				.replace(/'/g, '')
+				.replace(/"/g, '')
+				.replace(/,/g, '')
+				.replace(/;/g, '')
+				.replace(/\./g, '')
+				.replace(/:/g, '')
+				.replace(/#/g, '')
+				.replace(/ä/g, 'ae')
+				.replace(/ö/g, 'oe')
+				.replace(/ü/g, 'ue')
+				.replace(/ß/g, 'ss')
+				.replace(/²/g, '2')
+				.replace(/³/g, '3');
 		}
   }
 })

--- a/src/modals/SetlistSet.vue
+++ b/src/modals/SetlistSet.vue
@@ -372,24 +372,7 @@ export default {
 		},
 		// create a human readable record key of format YYYYMMDD-the-setlist-title
 		createSlug () {
-			return this.setlist.date.replace(/-/g, '') + '-' + this.slug(this.setlist.title);
-		},
-		slug (s) {
-			return s
-				.trim()
-				.toLowerCase()
-				.replace(/\s/g, '-')
-				.replace(/\//g, '-')
-				.replace(/'/g, '')
-				.replace(/"/g, '')
-				.replace(/,/g, '')
-				.replace(/;/g, '')
-				.replace(/\./g, '')
-				.replace(/:/g, '')
-				.replace(/ä/g, 'ae')
-				.replace(/ö/g, 'oe')
-				.replace(/ü/g, 'ue')
-				.replace(/ß/g, 'ss');
+			return this.setlist.date.replace(/-/g, '') + '-' + this.urlify(this.setlist.title);
 		},
 		cancel () {
 			this.$emit('closed');

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -518,25 +518,8 @@ export default {
 		},
 		// create a human readable record key of format YYYYMMDD-the-setlist-title
 		createSlug () {
-			return this.slug(this.song.title) + '-' + this.song.language;
+			return this.urlify(this.song.title) + '-' + this.song.language;
 		},
-		slug (s) {
-			return s
-				.trim()
-				.toLowerCase()
-				.replace(/\s/g, '-')
-				.replace(/\//g, '-')
-				.replace(/'/g, '')
-				.replace(/"/g, '')
-				.replace(/,/g, '')
-				.replace(/;/g, '')
-				.replace(/\./g, '')
-				.replace(/:/g, '')
-				.replace(/ä/g, 'ae')
-				.replace(/ö/g, 'oe')
-				.replace(/ü/g, 'ue')
-				.replace(/ß/g, 'ss');
-		}
 	},
 	computed: {
 		// filter song list by search query

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -443,7 +443,17 @@ export default {
 				// new song should be created
 				if (!this.existing) {
 					this.$db.collection('songs').doc(slug).set(processedSong).then(() => {
-						// TODO: add translation references
+						// persist translation references
+						if (processedSong.translations.length > 0) {
+							processedSong.translations.forEach(t => {
+								if (t in this.songs) {
+									let tsong = this.songs[t];
+									if (!tsong.translations.includes(slug)) {
+										this.$db.collection('songs').doc(t).update({ translations: tsong.translations.concat([slug]) });
+									}
+								}
+							});
+						}
 						this.$emit('closed');
 						this.$emit('reset');
 						processedSong = {};
@@ -461,8 +471,18 @@ export default {
 					// check if key remained (no title or language changes)
 					if (this.id == slug) {
 						// just update the existing song
-						this.$db.collection('songs').doc(this.id).update(processedSong).then(() => {
-							// TODO: update translation references
+						this.$db.collection('songs').doc(slug).update(processedSong).then(() => {
+							// persist translation references
+							if (processedSong.translations.length > 0) {
+								processedSong.translations.forEach(t => {
+									if (t in this.songs) {
+										let tsong = this.songs[t];
+										if (!tsong.translations.includes(slug)) {
+											this.$db.collection('songs').doc(t).update({ translations: tsong.translations.concat([slug]) });
+										}
+									}
+								});
+							}
 							this.$emit('closed');
 							this.$emit('reset');
 							processedSong = {};
@@ -477,9 +497,6 @@ export default {
 						// update key by adding a new song, removing the old one and update references in other fields
 						this.$db.collection('songs').doc(slug).set(processedSong).then(() => {
 							this.$db.collection('songs').doc(this.id).delete();
-							this.$emit('closed');
-							this.$emit('reset');
-							processedSong = {};
 							// check existing setlists for this song id and update to new slug
 							for (const setlistId in this.setlists) {
 								const setlist = this.setlists[setlistId];
@@ -506,7 +523,20 @@ export default {
 									this.$db.collection('songs').doc(songId).update({ translations: updatedTranslationsList });
 								}
 							}
-							// TODO: update translation references
+							// persist translation references
+							if (processedSong.translations.length > 0) {
+								processedSong.translations.forEach(t => {
+									if (t in this.songs) {
+										let tsong = this.songs[t];
+										if (!tsong.translations.includes(slug)) {
+											this.$db.collection('songs').doc(t).update({ translations: tsong.translations.concat([slug]) });
+										}
+									}
+								});
+							}
+							this.$emit('closed');
+							this.$emit('reset');
+							processedSong = {};
 							this.$router.push({ name: 'song-show', params: { id: slug }});
 							// toast success update message
 							this.$notify({

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -443,6 +443,7 @@ export default {
 				// new song should be created
 				if (!this.existing) {
 					this.$db.collection('songs').doc(slug).set(processedSong).then(() => {
+						// TODO: add translation references
 						this.$emit('closed');
 						this.$emit('reset');
 						processedSong = {};
@@ -459,8 +460,9 @@ export default {
 				else {
 					// check if key remained (no title or language changes)
 					if (this.id == slug) {
-						// just update the existing setlist
+						// just update the existing song
 						this.$db.collection('songs').doc(this.id).update(processedSong).then(() => {
+							// TODO: update translation references
 							this.$emit('closed');
 							this.$emit('reset');
 							processedSong = {};
@@ -504,6 +506,7 @@ export default {
 									this.$db.collection('songs').doc(songId).update({ translations: updatedTranslationsList });
 								}
 							}
+							// TODO: update translation references
 							this.$router.push({ name: 'song-show', params: { id: slug }});
 							// toast success update message
 							this.$notify({
@@ -548,9 +551,11 @@ export default {
 			if (this.search.translations != '') {
 				for (const key in this.songs) {
 					if (this.songs.hasOwnProperty(key)) {
+						// exclude self assignment
+						if (this.existing && this.id == key) continue;
+						// search in title and subtitle
 						const song = this.songs[key];
 						let search = this.search.translations.toLowerCase();
-						// search in title and subtitle
 						if (
 							song.title.toLowerCase().indexOf(search) !== -1 ||
 							song.subtitle.toLowerCase().indexOf(search) !== -1 ||
@@ -562,7 +567,9 @@ export default {
 				}
 				return songs;
 			} else {
-				return this.songs;
+				let songs = JSON.parse(JSON.stringify(this.songs));
+				if (this.existing) delete songs[this.id];
+				return songs;
 			}
 		},
 		// calculate wether form errors occured

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -468,11 +468,18 @@ export default {
 				}
 				// existing song should be updated
 				else {
+					let initialSong = this.initialSong; // remember initial song data before update
 					// check if key remained (no title or language changes)
 					if (this.id == slug) {
 						// just update the existing song
 						this.$db.collection('songs').doc(slug).update(processedSong).then(() => {
-							// persist translation references
+							// persist translation references by removing and adding them
+							let translationDiff = initialSong.translations.filter(t => !processedSong.translations.includes(t));
+							if (translationDiff.length > 0) {
+								translationDiff.forEach(s => {
+									this.$db.collection('songs').doc(s).update({ translations: this.songs[s].translations.filter(t => t != slug) });
+								});
+							}
 							if (processedSong.translations.length > 0) {
 								processedSong.translations.forEach(t => {
 									if (t in this.songs) {
@@ -523,7 +530,13 @@ export default {
 									this.$db.collection('songs').doc(songId).update({ translations: updatedTranslationsList });
 								}
 							}
-							// persist translation references
+							// persist translation references by removing and adding them
+							let translationDiff = initialSong.translations.filter(t => !processedSong.translations.includes(t));
+							if (translationDiff.length > 0) {
+								translationDiff.forEach(s => {
+									this.$db.collection('songs').doc(s).update({ translations: this.songs[s].translations.filter(t => t != slug) });
+								});
+							}
 							if (processedSong.translations.length > 0) {
 								processedSong.translations.forEach(t => {
 									if (t in this.songs) {


### PR DESCRIPTION
## Description of the Change

This change automatically sets references back to the current song when saving it. It also removes references when removing translation on song edit. It takes song slug changes into account.

## Benefits

Less manual work for song authors.

## Applicable Issues

Closes #127 
