### PR TITLE
Handle empty Setlists

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -246,6 +246,8 @@
     "dangerZone": "Gefahrenbereich",
     "deleteYourAccount": "Das Löschen deines Kontos kann nicht rückgängig gemacht werden. Bitte sei dir sicher.",
     "doTheImport": "Führe den Import aus zur Verarbeitung aller Datensätze der gewählten Datei",
+    "editSetlistAddSongs": "Bearbeite diese Setlist und füge Songs hinzu",
+    "emptySetlist": "Leere Setlist",
     "exportData": "Daten Export",
     "exportImportData": "Export und Import der SongDrive Daten",
     "forgotPassword": "Passwort vergessen?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -246,6 +246,8 @@
     "dangerZone": "Danger Zone",
     "deleteYourAccount": "Once you delete your account, there is no going back. Please be certain.",
     "doTheImport": "Do the import by processing all datasets in selected file",
+    "editSetlistAddSongs": "Edit this Setlist to add some songs",
+    "emptySetlist": "Empty Setlist",
     "exportData": "Export Data",
     "exportImportData": "Export and import SongDrive data",
     "forgotPassword": "Forgot Password?",

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -142,6 +142,7 @@
 			<!-- content -->
 			<div class="off-canvas-content">
 				<div class="container">
+					<!-- setlist data -->
 					<div class="columns">
 						<div v-if="ready.setlists && setlist" class="column col-12">
 							<h2>
@@ -170,7 +171,7 @@
 								</span>
 							</h3>
 						</div>
-						<div v-if="ready.songs && ready.setlists && setlist" class="column col-12">
+						<div v-if="ready.songs && ready.setlists && setlist && setlist.songs.length > 0" class="column col-12">
 							<table class="table table-striped table-hover">
 								<thead>
 									<tr>
@@ -243,8 +244,16 @@
 								</tbody>
 							</table>
 						</div>
+						<div v-if="ready.songs && ready.setlists && setlist && setlist.songs.length == 0" class="column col-12 empty">
+							<div class="empty-icon">
+								<ion-icon name="musical-notes-outline" class="icon-4x"></ion-icon>
+							</div>
+							<p class="empty-title h5">{{ $t('text.emptySetlist') }}</p>
+							<p class="empty-subtitle">{{ $t('text.editSetlistAddSongs') }}</p>
+						</div>
 					</div>
-					<div class="columns">
+					<!-- stats -->
+					<div v-if="ready.setlists && setlist && setlist.songs.length > 0" class="columns">
 						<div class="column col-12 mt-4">
 							<h2>{{ $t('widget.stats') }}</h2>
 						</div>


### PR DESCRIPTION
## Description of the Change

When a setlist contains no songs, there is now a proper information on the setlist preview instead of an empty table and empty chart sections.

![image](https://user-images.githubusercontent.com/5441654/171931464-8cc4824a-5fab-42ad-9807-05d24804cece.png)

## Benefits

Improved UX.

## Applicable Issues

None
