### PR TITLE
Song Notes

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -794,7 +794,9 @@ a {
 		.modal-container {
 			max-height: 100vh;
 		}
-
+		&.modal-wide .modal-container {
+			max-width: 100vw;
+		}
 		&.modal-full {
 			padding: 0;
 

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -794,10 +794,10 @@ a {
 		.modal-container {
 			max-height: 100vh;
 		}
-		
+
 		&.modal-full {
 			padding: 0;
-			
+
 			> .modal-overlay {
 				background: $black-color;
 			}

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -790,20 +790,21 @@ a {
 		background: rgba($dark-color, .75);
 	}
 	&.modal-lg {
+
 		.modal-container {
-			max-width: 100vw;
 			max-height: 100vh;
 		}
-
+		
 		&.modal-full {
 			padding: 0;
-
-			.modal-overlay {
+			
+			> .modal-overlay {
 				background: $black-color;
 			}
-			.modal-container {
+			> .modal-container {
 				background: $black-color;
 				height: 100vh;
+				max-width: 100vw;
 
 				.modal-footer {
 					position: absolute;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -139,6 +139,7 @@
   "key": {
     "B": "B",
     "F": "F",
+    "I": "I",
     "K": "K",
     "L": "L",
     "P": "P",
@@ -169,6 +170,7 @@
     "newSong": "Neuer Song",
     "resetPassword": "Passwort zurücksetzen",
     "signUp": "Registrieren",
+    "songInfo": "Song Informationen",
     "songSyntaxCheatsheet": "Song-Syntax Spickzettel",
     "tags": "Tags",
     "translations": "Übersetzungen"
@@ -378,6 +380,7 @@
     "chordsHide": "Akkorde ausblenden",
     "chordsShow": "Akkorde zeigen",
     "clear": "Suche und Filter zurücksetzen",
+    "infoSongData": "Song Informationen anzeigen",
     "keyReset": "Auf Original-Tonart zurücksetzen",
     "lightModeOnOff": "Hell-Modus an / aus",
     "nextSlide": "Nächste Folie",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -199,7 +199,7 @@
     "exampleSongAuthors": "z.B.  Edwin Othello Excell | John Newton",
     "exampleSongCcli": "z.B. 22025",
     "exampleSongContent": "Songtext mit Akkorden und Markern, z.B.:\n\n--v\n G             C  \nDas ist die Strophe\nD            G  \nEinfach ein Beispieltext\n\n--c\nD            C  \nDas ist der Refrain\nD            C      G  \nEinfach ein Beispieltext\n\n--b\n Em  \nDas ist die Bridge\nC            D  \nEinfach ein Beispieltext",
-    "exampleSongNote": "Allgemeine Notizen, z.B. Capo 3",
+    "exampleSongNote": "Allgemeine Notizen, z.B. Capo 3 oder Bewegungen für Kinder",
     "exampleSongPublisher": "z.B. Public Domain",
     "exampleSongSubtitle": "z.B. Wie süß der Klang",
     "exampleSongTitle": "z.B. Erstaunliche Gnade",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,6 +139,7 @@
   "key": {
     "B": "B",
     "F": "F",
+    "I": "I",
     "K": "K",
     "L": "L",
     "P": "P",
@@ -169,6 +170,7 @@
     "newSong": "New Song",
     "resetPassword": "Reset Password",
     "signUp": "Sign Up",
+    "songInfo": "Song Information",
     "songSyntaxCheatsheet": "Song Syntax Cheatsheet",
     "tags": "Tags",
     "translations": "Translations"
@@ -378,6 +380,7 @@
     "chordsHide": "Hide Chords",
     "chordsShow": "Show Chords",
     "clear": "Clear search and filter",
+    "infoSongData": "Show Song Information",
     "keyReset": "Reset to original key",
     "lightModeOnOff": "Light Mode on / off",
     "nextSlide": "Next Slide",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,7 +199,7 @@
     "exampleSongAuthors": "e.g.  Edwin Othello Excell | John Newton ",
     "exampleSongCcli": "e.g. 22025",
     "exampleSongContent": "song text with chords and markers, e.g.:\n\n--v\n  G          C  \nThis is the verse text\n D        G  \nJust an example text\n\n--c\n  D           C  \nThis is the chorus text\n D        C      G  \nJust an example text\n\n--b\n  Em  \nThis is the bridge text\n C        D  \nJust an example text",
-    "exampleSongNote": "general notes, e.g. capo 3",
+    "exampleSongNote": "general notes, e.g. capo 3 or movements for kids",
     "exampleSongPublisher": "e.g. Public Domain",
     "exampleSongSubtitle": "e.g. How sweet the sound",
     "exampleSongTitle": "e.g. Amazing Grace",

--- a/src/modals/InfoSongData.vue
+++ b/src/modals/InfoSongData.vue
@@ -1,0 +1,28 @@
+<template>
+	<div class="modal modal-md" :class="{ active: active }">
+		<a href="#" class="modal-overlay" aria-label="Close" @click.prevent="$emit('closed')"></a>
+		<div class="modal-container">
+			<div class="modal-header">
+				<a href="#" class="btn btn-clear float-right" aria-label="Close" @click.prevent="$emit('closed')"></a>
+				<div class="modal-title h5">{{ $t('modal.songInfo') }}</div>
+			</div>
+			<div class="modal-body">
+				<div v-if="song.note">
+					<div class="text-bold">{{ $t('field.note') }}</div>
+					<p v-html="song.note"></p>
+				</div>
+			</div>
+			<div class="modal-footer"></div>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'info-song-data',
+	props: {
+		active: Boolean,
+		song: Object
+	},
+}
+</script>

--- a/src/modals/SetlistPresent.vue
+++ b/src/modals/SetlistPresent.vue
@@ -8,6 +8,7 @@
 		@keydown.left.exact="$refs.presentation.slidePrev()"
 		@keydown.down.exact="$refs.presentation.slideNext()"
 		@keydown.right.exact="$refs.presentation.slideNext()"
+		@keydown.ctrl.73.prevent="modal.infosongdata = !modal.infosongdata"
 		@keydown.ctrl.83.prevent="autoSync = !autoSync"
 		@keydown.ctrl.66.prevent="hide = !hide"
 		@keydown.ctrl.76.prevent="dark = !dark"
@@ -73,6 +74,16 @@
 				<span class="clock px-4">{{ timeonly }}</span>
 				<a
 					class="btn btn-xl btn-fw btn-gray btn-toggle tooltip ml-4"
+					:class="{ 'btn-secondary': !modal.infosongdata, 'btn-primary': modal.infosongdata }"
+					href="#"
+					aria-label="Song Data"
+					@click="modal.infosongdata = true"
+					:data-tooltip="$t('tooltip.infoSongData') + '\n' + $t('key.ctrl') + ' + ' + $t('key.I')"
+				>
+					<ion-icon name="information-outline" class="icon-1-5x"></ion-icon>
+				</a>
+				<a
+					class="btn btn-xl btn-fw btn-gray btn-toggle tooltip ml-1"
 					:class="{ 'btn-secondary': !autoSync, 'btn-primary': autoSync }"
 					href="#"
 					aria-label="AutoSync"
@@ -152,6 +163,13 @@
 				</div>
 			</div>
 		</div>
+		<!-- modal: info song note -->
+		<InfoSongData
+			v-if="modal.infosongdata"
+			:active="modal.infosongdata"
+			:song="songs[currentPosition]"
+			@closed="modal.infosongdata = false"
+		/>
 	</div>
 </template>
 
@@ -161,6 +179,7 @@ import { Hooper, Slide, Pagination as HooperPagination } from 'hooper';
 import 'hooper/dist/hooper.css';
 // get internal components
 import SongContent from '@/partials/SongContent';
+import InfoSongData from '@/modals/InfoSongData';
 
 export default {
 	name: 'setlist-present',
@@ -168,7 +187,8 @@ export default {
 		Hooper,
 		Slide,
 		HooperPagination,
-		SongContent
+		SongContent,
+		InfoSongData,
 	},
 	props: {
 		active: Boolean,
@@ -185,6 +205,9 @@ export default {
 			settings: {
 				infiniteScroll: false,
 				keysControl: true,
+			},
+			modal: {
+				infosongdata: false
 			},
 			currentPosition: 0,
 			autoSync: false,

--- a/src/modals/SetlistSet.vue
+++ b/src/modals/SetlistSet.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="modal modal-lg" :class="{ active: active }">
+	<div class="modal modal-lg modal-wide" :class="{ active: active }">
 		<a href="#" class="modal-overlay" aria-label="Close" @click.prevent="cancel"></a>
 		<div v-if="setlist && ready.songs" class="modal-container">
 			<div class="modal-header">

--- a/src/modals/SongPresent.vue
+++ b/src/modals/SongPresent.vue
@@ -4,6 +4,7 @@
 		:class="{ active: active, light: !dark }"
 		ref="container"
 		tabindex="0"
+		@keydown.ctrl.73.prevent="modal.infosongdata = !modal.infosongdata"
 		@keydown.ctrl.76.prevent="dark = !dark"
 		@keydown.ctrl.75.prevent="chords = !chords"
 		@keydown.esc.exact="$emit('closed')"
@@ -12,13 +13,13 @@
 		<div class="modal-container p-0">
 			<div class="modal-header">
 				<div class="modal-title h5 text-center">
-					{{ title }}
-					<span class="modal-subtitle h6 text-gray ml-3">{{ subtitle }}</span>
+					{{ song.title }}
+					<span class="modal-subtitle h6 text-gray ml-3">{{ song.subtitle }}</span>
 				</div>
 			</div>
-			<div v-if="content" class="modal-body">
+			<div v-if="song.content" class="modal-body">
 				<SongContent
-					:content="content"
+					:content="song.content"
 					:chords="chords"
 					:tuning="tuning"
 					:presentation="true"
@@ -26,6 +27,16 @@
 				/>
 			</div>
 			<div class="modal-footer">
+				<a
+					class="btn btn-xl btn-fw btn-gray btn-toggle tooltip ml-1"
+					:class="{ 'btn-secondary': !modal.infosongdata, 'btn-primary': modal.infosongdata }"
+					href="#"
+					aria-label="Song Data"
+					@click="modal.infosongdata = true"
+					:data-tooltip="$t('tooltip.infoSongData') + '\n' + $t('key.ctrl') + ' + ' + $t('key.I')"
+				>
+					<ion-icon name="information-outline" class="icon-1-5x"></ion-icon>
+				</a>
 				<a
 					class="btn btn-xl btn-fw btn-gray btn-toggle tooltip ml-1"
 					:class="{ 'btn-secondary': dark, 'btn-primary': !dark }"
@@ -57,29 +68,39 @@
 				</a>
 			</div>
 		</div>
+		<!-- modal: info song note -->
+		<InfoSongData
+			v-if="modal.infosongdata"
+			:active="modal.infosongdata"
+			:song="song"
+			@closed="modal.infosongdata = false"
+		/>
 	</div>
 </template>
 
 <script>
 // get components
 import SongContent from '@/partials/SongContent';
+import InfoSongData from '@/modals/InfoSongData';
 
 export default {
 	name: 'song-present',
 	components: {
-		SongContent
+		SongContent,
+		InfoSongData,
 	},
 	props: {
 		active: Boolean,
-		title: String,
-		subtitle: String,
-		content: String,
+		song: Object,
 		chords: Boolean,
 		tuning: Number,
 	},
 	data () {
 		return {
 			dark: true,
+			modal: {
+				infosongdata: false
+			}
 		};
 	},
 	methods: {

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<!-- main modal: set song -->
-		<div class="modal modal-lg" :class="{ active: active }">
+		<div class="modal modal-lg modal-wide" :class="{ active: active }">
 			<a href="#" class="modal-overlay" aria-label="Close" @click.prevent="$emit('closed')"></a>
 			<div v-if="song && ready.songs" class="modal-container">
 				<div class="modal-header">

--- a/src/modals/SongSet.vue
+++ b/src/modals/SongSet.vue
@@ -116,7 +116,8 @@
 												v-model="song.publisher"
 												class="form-input"
 												id="publisher"
-												:placeholder="$t('placeholder.exampleSongPublisher')" rows="2"
+												:placeholder="$t('placeholder.exampleSongPublisher')"
+												rows="2"
 											></textarea>
 										</div>
 									</div>
@@ -135,13 +136,14 @@
 									<div class="column col-8 col-md-12">
 										<div class="form-group">
 											<label class="form-label" for="note">{{ $t('field.note') }}</label>
-											<input
+											<textarea
 												v-model="song.note"
 												class="form-input"
 												id="note"
 												type="text"
 												:placeholder="$t('placeholder.exampleSongNote')"
-											>
+												rows="2"
+											></textarea>
 										</div>
 									</div>
 									<div class="column col-4 col-md-12">

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -716,6 +716,7 @@ export default {
 						// footer with ccli#, author names and (c) year publisher
 						{
 							text: [
+								song.note ? this.$t('field.note') + ':\n' + song.note + '\n\n' : '',
 								song.ccli ? 'CCLI Song Nr.: ' + song.ccli + '\n' : '',
 								song.authors ? song.authors + '\n' : '',
 								'\u00A9 ' + (song.year ? song.year + ' ' : '') + song.publisher

--- a/src/views/Shortcuts.vue
+++ b/src/views/Shortcuts.vue
@@ -57,7 +57,7 @@
 											<kbd><ion-icon name="arrow-forward"></ion-icon></kbd> /
 											<kbd><ion-icon name="arrow-up"></ion-icon></kbd>
 										</td>
-										<td><ion-icon name="musical-note"></ion-icon></td>
+										<td></td>
 										<td>{{ $t('tooltip.transposeUp') }}</td>
 									</tr>
 									<tr>
@@ -65,7 +65,7 @@
 											<kbd><ion-icon name="arrow-back"></ion-icon></kbd> /
 											<kbd><ion-icon name="arrow-down"></ion-icon></kbd>
 										</td>
-										<td><ion-icon name="musical-note"></ion-icon></td>
+										<td></td>
 										<td>{{ $t('tooltip.transposeDown') }}</td>
 									</tr>
 									<tr>
@@ -77,6 +77,11 @@
 										<td><kbd>{{ $t('key.ctrl') }}</kbd>&nbsp;+&nbsp;<kbd>{{ $t('key.P') }}</kbd></td>
 										<td><ion-icon name="videocam-outline"></ion-icon></td>
 										<td>{{ $t('tooltip.presentationStart') }}</td>
+									</tr>
+									<tr>
+										<td><kbd>{{ $t('key.ctrl') }}</kbd>&nbsp;+&nbsp;<kbd>{{ $t('key.I') }}</kbd></td>
+										<td><ion-icon name="information-outline"></ion-icon></td>
+										<td>{{ $t('tooltip.infoSongData') }}</td>
 									</tr>
 									<tr>
 										<td><kbd>{{ $t('key.ctrl') }}</kbd>&nbsp;+&nbsp;<kbd>{{ $t('key.L') }}</kbd></td>
@@ -136,6 +141,16 @@
 										<td><kbd>{{ $t('key.ctrl') }}</kbd>&nbsp;+&nbsp;<kbd>{{ $t('key.B') }}</kbd></td>
 										<td><ion-icon name="eye-off-outline"></ion-icon></td>
 										<td>{{ $t('tooltip.presentationShow') }} / {{ $t('tooltip.presentationHide') }}</td>
+									</tr>
+									<tr>
+										<td><kbd>{{ $t('key.ctrl') }}</kbd>&nbsp;+&nbsp;<kbd>{{ $t('key.I') }}</kbd></td>
+										<td><ion-icon name="information-outline"></ion-icon></td>
+										<td>{{ $t('tooltip.infoSongData') }}</td>
+									</tr>
+									<tr>
+										<td><kbd>{{ $t('key.ctrl') }}</kbd>&nbsp;+&nbsp;<kbd>{{ $t('key.L') }}</kbd></td>
+										<td><ion-icon name="contrast-outline"></ion-icon></td>
+										<td>{{ $t('tooltip.lightModeOnOff') }}</td>
 									</tr>
 									<tr>
 										<td><kbd>{{ $t('key.esc') }}</kbd></td>

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -189,7 +189,7 @@
 					</div>
 					<!-- song footer with meta data -->
 					<footer class="columns mt-4 pt-4">
-						<div v-if="ready.songs && song && ready.tags" class="column col-6 text-small">
+						<div v-if="ready.songs && song && ready.tags" class="column col-6 col-md-12 text-small">
 							<p>{{ song.authors }}</p>
 							<p>
 								<!-- youtube -->
@@ -232,7 +232,7 @@
 							</p>
 							<p class="text-gray text-breaks">&copy; {{ song.year }} {{ song.publisher }}</p>
 						</div>
-						<div v-if="ready.songs && song && song.note" class="column col-6">
+						<div v-if="ready.songs && song && song.note" class="column col-6 col-md-12">
 							<h3>{{ $t('field.note') }}</h3>
 							<p v-html="song.note.replace(/\n/gi, '<br>')"></p>
 						</div>
@@ -481,6 +481,7 @@ export default {
 				{
 					style: 'copyright',
 					text: [
+						this.song.note ? this.$t('field.note') + ':\n' + this.song.note + '\n\n' : '',
 						this.song.ccli ? 'CCLI Song Nr.: ' + this.song.ccli + '\n' : '',
 						this.song.authors ? this.song.authors + '\n' : '',
 						'\u00A9 ' + (this.song.year ? this.song.year + ' ' : '') + this.song.publisher

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -188,53 +188,55 @@
 						</div>
 					</div>
 					<!-- song footer with meta data -->
-					<div class="columns mt-4 pt-4">
-						<div v-if="ready.songs && song && ready.tags" class="column">
-							<footer class="text-small">
-								<p>{{ song.authors }}</p>
-								<p>
-									<!-- youtube -->
-									<a
-										v-if="song.youtube"
-										:href="'https://youtu.be/' + song.youtube"
-										class="mr-2"
-										target="_blank"
-									>
-										<span class="label px-2 py-1">
-											<ion-icon name="logo-youtube" class="icon-sm mr-1"></ion-icon>
-											{{ $t('field.youtube') }}
-											<ion-icon name="open-outline" class="icon-sm ml-1"></ion-icon>
-										</span>
-									</a>
-									<!-- ccli -->
-									<a
-										v-if="song.ccli"
-										:href="'https://songselect.ccli.com/Songs/' + song.ccli"
-										class="mr-4"
-										target="_blank"
-									>
-										<span class="label px-2 py-1">
-											{{ $t('field.ccli') }}
-											<ion-icon name="open-outline" class="icon-sm ml-1"></ion-icon>
-										</span>
-									</a>
-									<!-- tags -->
-									<router-link
-										v-for="tag in song.tags"
-										:key="tag"
-										:to="{ name: 'songs-tag', params: { tag: tag }}"
-										class="mr-2"
-									>
-										<span class="label px-2 py-1">
-											<ion-icon name="pricetag-outline" class="icon-sm mr-1"></ion-icon>
-											{{ tags[tag][$i18n.locale] ? tags[tag][$i18n.locale] : tag }}
-										</span>
-									</router-link>
-								</p>
-								<p class="text-gray text-breaks">&copy; {{ song.year }} {{ song.publisher }}</p>
-							</footer>
+					<footer class="columns mt-4 pt-4">
+						<div v-if="ready.songs && song && ready.tags" class="column col-6 text-small">
+							<p>{{ song.authors }}</p>
+							<p>
+								<!-- youtube -->
+								<a
+									v-if="song.youtube"
+									:href="'https://youtu.be/' + song.youtube"
+									class="mr-2"
+									target="_blank"
+								>
+									<span class="label px-2 py-1">
+										<ion-icon name="logo-youtube" class="icon-sm mr-1"></ion-icon>
+										{{ $t('field.youtube') }}
+										<ion-icon name="open-outline" class="icon-sm ml-1"></ion-icon>
+									</span>
+								</a>
+								<!-- ccli -->
+								<a
+									v-if="song.ccli"
+									:href="'https://songselect.ccli.com/Songs/' + song.ccli"
+									class="mr-4"
+									target="_blank"
+								>
+									<span class="label px-2 py-1">
+										{{ $t('field.ccli') }}
+										<ion-icon name="open-outline" class="icon-sm ml-1"></ion-icon>
+									</span>
+								</a>
+								<!-- tags -->
+								<router-link
+									v-for="tag in song.tags"
+									:key="tag"
+									:to="{ name: 'songs-tag', params: { tag: tag }}"
+									class="mr-2"
+								>
+									<span class="label px-2 py-1">
+										<ion-icon name="pricetag-outline" class="icon-sm mr-1"></ion-icon>
+										{{ tags[tag][$i18n.locale] ? tags[tag][$i18n.locale] : tag }}
+									</span>
+								</router-link>
+							</p>
+							<p class="text-gray text-breaks">&copy; {{ song.year }} {{ song.publisher }}</p>
 						</div>
-					</div>
+						<div v-if="ready.songs && song && song.note" class="column col-6">
+							<h3>{{ $t('field.note') }}</h3>
+							<p v-html="song.note.replace(/\n/gi, '<br>')"></p>
+						</div>
+					</footer>
 				</div>
 			</div>
 			<!-- modals -->

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -187,7 +187,7 @@
 							/>
 						</div>
 					</div>
-					<!-- song footer with meta data -->
+					<!-- song footer with info and data about the song -->
 					<footer class="columns mt-4 pt-4">
 						<div v-if="ready.songs && song && ready.tags" class="column col-6 col-md-12 text-small">
 							<p>{{ song.authors }}</p>
@@ -233,7 +233,6 @@
 							<p class="text-gray text-breaks">&copy; {{ song.year }} {{ song.publisher }}</p>
 						</div>
 						<div v-if="ready.songs && song && song.note" class="column col-6 col-md-12">
-							<h3>{{ $t('field.note') }}</h3>
 							<p v-html="song.note.replace(/\n/gi, '<br>')"></p>
 						</div>
 					</footer>
@@ -264,9 +263,7 @@
 			<SongPresent
 				v-if="modal.present"
 				:active="modal.present"
-				:title="song.title"
-				:subtitle="song.subtitle"
-				:content="song.content"
+				:song="song"
 				:chords="chords"
 				:tuning="tuning"
 				@chords="chords = !chords"


### PR DESCRIPTION
## Description of the Change

This change makes song notes more useful by showing it on different places in SongDrive. It adds an info button to song and setlist presentation views (also accessible by CTRL+I) and also attaches notes to song preview and PDF export.

## Benefits

Song Notes can now be used for anything that's related to the song.

## Applicable Issues

Closes #137 