### PR TITLE
QR codes for YouTube links

### DIFF
--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -627,7 +627,12 @@ export default {
 					footer: {
 						font: 'FiraSans',
 						fontSize: 8,
-						margin: [ 0, 30, 0, 0 ]
+						margin: [ 0, 20, 0, 0 ]
+					},
+					qr: {
+						font: 'FiraMono',
+						fontSize: 8,
+						alignment: 'right'
 					}
 				}
 			};
@@ -665,12 +670,12 @@ export default {
 			];
 		},
 		getPdfSongsheets () {
-			var sheets = [];
+			let sheets = [];
 			for (const key in this.setlist.songs) {
 				if (this.setlist.songs.hasOwnProperty(key) && this.setlist.songs[key].id in this.songs) {
 					const song = this.songs[this.setlist.songs[key].id];
 					// handle song content parts
-					var content = [];
+					let content = [];
 					let parts = this.parsedContent(
 						song.content,
 						song.customTuning ? song.customTuningDelta : 0,
@@ -702,7 +707,31 @@ export default {
 							});
 						}
 					});
-					var meta = [
+					// create footer
+					let footer = [{
+						// imprint with ccli#, author names and (c) year publisher
+						width: '*',
+						style: 'footer',
+						text: [
+							song.note ? this.$t('field.note') + ':\n' + song.note + '\n\n' : '',
+							song.ccli ? 'CCLI Song Nr.: ' + song.ccli + '\n' : '',
+							song.authors ? song.authors + '\n' : '',
+							'\u00A9 ' + (song.year ? song.year + ' ' : '') + song.publisher
+						]
+					}];
+					if (song.youtube) {
+						footer.push({
+							// QR code for YouTube link
+							width: '140',
+							margin: [ 0, 20, 0, 0 ],
+							stack: [
+								{ text: 'https://youtu.be/' + song.youtube, style: 'qr' },
+								{ qr: 'https://youtu.be/' + song.youtube, fit: '90', style: 'qr', margin: [ 0, 5, 0, 0 ] }
+							]
+						});
+					}
+					// put songsheet together
+					let songsheet = [
 						// song title [tuning] with a line beneath
 						{ text: song.title.toUpperCase(), style: 'header' },
 						{ canvas: [{ type: 'line', x1: 0, y1: 0, x2: 505, y2: 0, lineWidth: .5 }] },
@@ -713,22 +742,13 @@ export default {
 							margin: [ 0, 4, 0, 0 ]
 						},
 						content,
-						// footer with ccli#, author names and (c) year publisher
-						{
-							text: [
-								song.note ? this.$t('field.note') + ':\n' + song.note + '\n\n' : '',
-								song.ccli ? 'CCLI Song Nr.: ' + song.ccli + '\n' : '',
-								song.authors ? song.authors + '\n' : '',
-								'\u00A9 ' + (song.year ? song.year + ' ' : '') + song.publisher
-							],
-							style: 'footer'
-						}
+						{ columnGap: 8, columns: footer }
 					];
 					// add page break after every song exept for the last
 					if (this.setlist.songs.length > 0 && key < this.setlist.songs.length-1) {
-						meta.push({ text: '', pageBreak: 'after', style: 'code' });
+						songsheet.push({ text: '', pageBreak: 'after', style: 'code' });
 					}
-					sheets = sheets.concat(meta);
+					sheets = sheets.concat(songsheet);
 				}
 			}
 			return sheets;

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -446,7 +446,8 @@ export default {
 		// prepare song content for PDF export
 		getPdfSongContent () {
 			// handle all song parts
-			var content = [], parts = this.parsedContent(this.song.content, this.tuning, this.chords, false);
+			let content = [];
+			let parts = this.parsedContent(this.song.content, this.tuning, this.chords, false);
 			parts.forEach((part) => {
 				if (part.type == 'v' && part.number != '0') {
 					content.push({
@@ -473,37 +474,36 @@ export default {
 					});
 				}
 			});
+			// create footer
+			let footer = [{
+				// imprint with ccli#, author names and (c) year publisher
+				width: '*',
+				style: 'copyright',
+				text: [
+					this.song.note ? this.$t('field.note') + ':\n' + this.song.note + '\n\n' : '',
+					this.song.ccli ? 'CCLI Song Nr.: ' + this.song.ccli + '\n' : '',
+					this.song.authors ? this.song.authors + '\n' : '',
+					'\u00A9 ' + (this.song.year ? this.song.year + ' ' : '') + this.song.publisher
+				]
+			}];
+			if (this.song.youtube) {
+				footer.push({
+					// QR code for YouTube link
+					width: '140',
+					margin: [ 0, 20, 0, 0 ],
+					stack: [
+						{ text: 'https://youtu.be/' + this.song.youtube, style: 'qr' },
+						{ qr: 'https://youtu.be/' + this.song.youtube, fit: '90', style: 'qr', margin: [ 0, 5, 0, 0 ] }
+					]
+				});
+			}
 			// return array with song data ready for pdfMake
 			return [
 				// song title [tuning] with a line beneath
 				{ text: this.song.title.toUpperCase() + (this.tuning ? '  [' + this.keyScale()[(12 + this.keyScale().indexOf(this.song.tuning) + (this.tuning % 12)) % 12] + ']' : ''), style: 'header' },
 				{ canvas: [{ type: 'line', x1: 0, y1: 0, x2: 505, y2: 0, lineWidth: .5 }] },
 				content,
-				{
-					columnGap: 8,
-					columns: [
-						{
-							// imprint with ccli#, author names and (c) year publisher
-							width: '*',
-							style: 'copyright',
-							text: [
-								this.song.note ? this.$t('field.note') + ':\n' + this.song.note + '\n\n' : '',
-								this.song.ccli ? 'CCLI Song Nr.: ' + this.song.ccli + '\n' : '',
-								this.song.authors ? this.song.authors + '\n' : '',
-								'\u00A9 ' + (this.song.year ? this.song.year + ' ' : '') + this.song.publisher
-							]
-						},
-						{
-							// QR code for YouTube link
-							width: '140',
-							margin: [ 0, 20, 0, 0 ],
-							stack: [
-								{ text: 'https://youtu.be/' + this.song.youtube, style: 'qr' },
-								{ qr: 'https://youtu.be/' + this.song.youtube, fit: '90', style: 'qr', margin: [ 0, 5, 0, 0 ] }
-							]
-						}
-					]
-				}
+				{ columnGap: 8, columns: footer }
 			];
 		}
 	},

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -427,6 +427,11 @@ export default {
 						font: 'FiraSans',
 						fontSize: 8,
 						margin: [ 0, 20, 0, 0 ]
+					},
+					qr: {
+						font: 'FiraMono',
+						fontSize: 8,
+						alignment: 'right'
 					}
 				}
 			};
@@ -474,14 +479,29 @@ export default {
 				{ text: this.song.title.toUpperCase() + (this.tuning ? '  [' + this.keyScale()[(12 + this.keyScale().indexOf(this.song.tuning) + (this.tuning % 12)) % 12] + ']' : ''), style: 'header' },
 				{ canvas: [{ type: 'line', x1: 0, y1: 0, x2: 505, y2: 0, lineWidth: .5 }] },
 				content,
-				// imprint with ccli#, author names and (c) year publisher
 				{
-					style: 'copyright',
-					text: [
-						this.song.note ? this.$t('field.note') + ':\n' + this.song.note + '\n\n' : '',
-						this.song.ccli ? 'CCLI Song Nr.: ' + this.song.ccli + '\n' : '',
-						this.song.authors ? this.song.authors + '\n' : '',
-						'\u00A9 ' + (this.song.year ? this.song.year + ' ' : '') + this.song.publisher
+					columnGap: 8,
+					columns: [
+						{
+							// imprint with ccli#, author names and (c) year publisher
+							width: '*',
+							style: 'copyright',
+							text: [
+								this.song.note ? this.$t('field.note') + ':\n' + this.song.note + '\n\n' : '',
+								this.song.ccli ? 'CCLI Song Nr.: ' + this.song.ccli + '\n' : '',
+								this.song.authors ? this.song.authors + '\n' : '',
+								'\u00A9 ' + (this.song.year ? this.song.year + ' ' : '') + this.song.publisher
+							]
+						},
+						{
+							// QR code for YouTube link
+							width: '140',
+							margin: [ 0, 20, 0, 0 ],
+							stack: [
+								{ text: 'https://youtu.be/' + this.song.youtube, style: 'qr' },
+								{ qr: 'https://youtu.be/' + this.song.youtube, fit: '90', style: 'qr', margin: [ 0, 5, 0, 0 ] }
+							]
+						}
 					]
 				}
 			];


### PR DESCRIPTION
## Description of the Change

This change extends the song and songsheets PDF export by a QR code for the YouTube link. If set, the youtube link with QR code is shown to the right of the footer copyright notice.

![image](https://user-images.githubusercontent.com/5441654/173917488-fc152a6e-1d81-4f47-a124-46a3c8280791.png)

## Benefits

Printed songsheets now hold a convenient way to quickly open the youtube link to play the song.

## Applicable Issues

Closes #138 
