### PR TITLE
Synced setlist presentations now handle song order changes

### DIFF
--- a/src/modals/SetlistPresent.vue
+++ b/src/modals/SetlistPresent.vue
@@ -299,8 +299,9 @@ watch (autoSync, () => {
 		dark.value = !props.remoteLight;
 	}
 });
-// watcher: maximize fontsize again when chords are toggled
+// watcher: maximize fontsize again when chords are toggled or songs change
 watch (() => props.chords, () => maximizeFontsize());
+watch (() => props.songs, () => maximizeFontsize());
 // watcher: update local position if autoSync is on and remote position was updated
 watch (() => props.position, () => {
 	if (autoSync.value) {


### PR DESCRIPTION
<!--
* Filling out this template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change makes changes to song order during a synced presentation be correctly handled.

## Benefits

Live song order changes during presentations.

## Applicable Issues

Closes #150 
