### PR TITLE
Song navigation from setlist

### DIFF
--- a/src/elements/ZoneInfo.vue
+++ b/src/elements/ZoneInfo.vue
@@ -7,7 +7,9 @@
   <div class="
     -mt-7 px-1.5 -ml-1.5 inline-block uppercase max-w-max tracking-widest text-sm
     bg-blade-100 dark:bg-blade-850 text-blade-500
-  ">{{ label }}</div>
+  ">
+    <slot name="label"></slot>
+  </div>
   <!-- close button -->
   <div
     v-if="closable"
@@ -33,7 +35,6 @@ const { t } = useI18n();
 
 // component properties
 defineProps({
-  label:    String,
   closable: Boolean,
 });
 

--- a/src/elements/ZoneInfo.vue
+++ b/src/elements/ZoneInfo.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="
+    relative min-w-[50vw] rounded-sm border-blade-400 border-2 flex flex-col gap-4 p-4
+    dark:border-blade-800
+  ">
+    <!-- label -->
+    <div class="
+      absolute -top-3 left-2.5 uppercase tracking-widest text-sm px-1.5
+      bg-blade-100 dark:bg-blade-850 text-blade-500
+    ">{{ label }}</div>
+    <!-- close button -->
+    <div
+      v-if="closable"
+      class="bg-blade-100 dark:bg-blade-850 text-blade-500 cursor-pointer absolute -top-3 -right-2"
+      @click="emit('close')"
+    >
+      <icon-x class="w-5 h-5" />
+    </div>
+    <!-- content -->
+    <slot></slot>
+  </div>
+</template>
+
+<script setup>
+// icons
+import { IconX } from '@tabler/icons-vue';
+
+// component properties
+defineProps({
+  label:    String,
+  closable: Boolean,
+})
+
+// component emits
+const emit = defineEmits(['close']);
+</script>

--- a/src/elements/ZoneInfo.vue
+++ b/src/elements/ZoneInfo.vue
@@ -1,25 +1,25 @@
 <template>
+<div class="
+  relative rounded-sm border-blade-400 border-2 flex flex-col gap-4 p-4
+  dark:border-blade-800
+">
+  <!-- label -->
   <div class="
-    relative sm:min-w-[40vw] rounded-sm border-blade-400 border-2 flex flex-col gap-4 p-4
-    dark:border-blade-800
-  ">
-    <!-- label -->
-    <div class="
-      sm:absolute sm:-top-3 sm:left-2.5 uppercase tracking-widest text-sm sm:px-1.5
-      sm:bg-blade-100 sm:dark:bg-blade-850 text-blade-500
-    ">{{ label }}</div>
-    <!-- close button -->
-    <div
-      v-if="closable"
-      class="bg-blade-100 dark:bg-blade-850 text-blade-500 cursor-pointer absolute -top-3 -right-2"
-      @click="emit('close')"
-      :title="t('tooltip.hideThisSection')"
-    >
-      <icon-x class="w-5 h-5" />
-    </div>
-    <!-- content -->
-    <slot></slot>
+    -mt-7 px-1.5 -ml-1.5 inline-block uppercase max-w-max tracking-widest text-sm
+    bg-blade-100 dark:bg-blade-850 text-blade-500
+  ">{{ label }}</div>
+  <!-- close button -->
+  <div
+    v-if="closable"
+    class="bg-blade-100 dark:bg-blade-850 text-blade-500 cursor-pointer absolute -top-3 -right-2"
+    @click="emit('close')"
+    :title="t('tooltip.hideThisSection')"
+  >
+    <icon-x class="w-5 h-5" />
   </div>
+  <!-- content -->
+  <slot></slot>
+</div>
 </template>
 
 <script setup>

--- a/src/elements/ZoneInfo.vue
+++ b/src/elements/ZoneInfo.vue
@@ -1,18 +1,19 @@
 <template>
   <div class="
-    relative min-w-[50vw] rounded-sm border-blade-400 border-2 flex flex-col gap-4 p-4
+    relative sm:min-w-[40vw] rounded-sm border-blade-400 border-2 flex flex-col gap-4 p-4
     dark:border-blade-800
   ">
     <!-- label -->
     <div class="
-      absolute -top-3 left-2.5 uppercase tracking-widest text-sm px-1.5
-      bg-blade-100 dark:bg-blade-850 text-blade-500
+      sm:absolute sm:-top-3 sm:left-2.5 uppercase tracking-widest text-sm sm:px-1.5
+      sm:bg-blade-100 sm:dark:bg-blade-850 text-blade-500
     ">{{ label }}</div>
     <!-- close button -->
     <div
       v-if="closable"
       class="bg-blade-100 dark:bg-blade-850 text-blade-500 cursor-pointer absolute -top-3 -right-2"
       @click="emit('close')"
+      :title="t('tooltip.hideThisSection')"
     >
       <icon-x class="w-5 h-5" />
     </div>
@@ -22,14 +23,19 @@
 </template>
 
 <script setup>
+import { useI18n } from 'vue-i18n';
+
 // icons
 import { IconX } from '@tabler/icons-vue';
+
+// component constants
+const { t } = useI18n();
 
 // component properties
 defineProps({
   label:    String,
   closable: Boolean,
-})
+});
 
 // component emits
 const emit = defineEmits(['close']);

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -404,6 +404,7 @@
     "copySetlist": "Liste in die Zwischenablage kopieren",
     "downloadSetlist": "Liste oder Liedzettel herunterladen",
     "downloadSong": "Liedzettel herunterladen",
+    "hideThisSection": "Diesen Bereich ausblenden",
     "infoSongData": "Song Informationen anzeigen",
     "invertColors": "Farben umkehren",
     "keyReset": "Auf Original-Tonart zurücksetzen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -404,6 +404,7 @@
     "copySetlist": "Copy list to clipboard",
     "downloadSetlist": "Download list or songsheets",
     "downloadSong": "Download songsheet",
+    "hideThisSection": "Hide this section",
     "infoSongData": "Show Song Information",
     "invertColors": "Invert Colors",
     "keyReset": "Reset to original key",

--- a/src/modals/SetlistSet.vue
+++ b/src/modals/SetlistSet.vue
@@ -214,7 +214,7 @@
 								</button>
 								<div class="flex items-center">
 									<secondary-button @click.prevent="tuneDown(i)" class="w-6 h-6 !p-1">
-										<icon-arrow-left class="w-4 h-4 stroke-2 shrink-0" />
+										<icon-chevron-left class="w-4 h-4 stroke-2 shrink-0" />
 									</secondary-button>
 									<figure
 										class="flex justify-center items-center bg-spring-700 text-white font-semibold py-1 w-8"
@@ -223,7 +223,7 @@
 										<div class="-mt-0.5">{{ element.tuning ? element.tuning : songs[element.id].tuning }}</div>
 									</figure>
 									<secondary-button @click.prevent="tuneUp(i)" class="w-6 h-6 !p-1">
-										<icon-arrow-right class="w-4 h-4 stroke-2 shrink-0" />
+										<icon-chevron-right class="w-4 h-4 stroke-2 shrink-0" />
 									</secondary-button>
 								</div>
 								<div class="flex flex-col overflow-hidden">
@@ -284,6 +284,8 @@ import {
 	IconArrowLeft,
 	IconArrowRight,
 	IconCalendar,
+	IconChevronLeft,
+	IconChevronRight,
 	IconDeviceFloppy,
 	IconFilter,
 	IconLoader2,

--- a/src/modals/SetlistSet.vue
+++ b/src/modals/SetlistSet.vue
@@ -205,7 +205,7 @@
 						ghost-class="!bg-blade-950"
 						class="overflow-y-scroll h-full flex flex-col gap-1 mt-3"
 					>
-						<template #item="{ element }">
+						<template #item="{ element, index }">
 							<div
 								class="flex items-center gap-2 p-1 hover:bg-blade-200 dark:hover:bg-blade-800"
 							>
@@ -213,7 +213,7 @@
 									<icon-menu-order class="handle w-5 h-5" />
 								</button>
 								<div class="flex items-center">
-									<secondary-button @click.prevent="tuneDown(i)" class="w-6 h-6 !p-1">
+									<secondary-button @click.prevent="tuneDown(index)" class="w-6 h-6 !p-1">
 										<icon-chevron-left class="w-4 h-4 stroke-2 shrink-0" />
 									</secondary-button>
 									<figure
@@ -222,7 +222,7 @@
 									>
 										<div class="-mt-0.5">{{ element.tuning ? element.tuning : songs[element.id].tuning }}</div>
 									</figure>
-									<secondary-button @click.prevent="tuneUp(i)" class="w-6 h-6 !p-1">
+									<secondary-button @click.prevent="tuneUp(index)" class="w-6 h-6 !p-1">
 										<icon-chevron-right class="w-4 h-4 stroke-2 shrink-0" />
 									</secondary-button>
 								</div>

--- a/src/router.js
+++ b/src/router.js
@@ -4,17 +4,17 @@ import Dashboard from '@/views/Dashboard.vue';
 export default createRouter({
 	history: createWebHistory(import.meta.env.BASE_URL),
 	routes: [
-		{ path: '/',               name: 'dashboard',     component: Dashboard },
+		{ path: '/',                         name: 'dashboard',     component: Dashboard },
 		// lazy load all other routes
-		{ path: '/songs',          name: 'songs',         component: () => import('@/views/Songs.vue')         },
-		{ path: '/songs/:tag',     name: 'songs-tag',     component: () => import('@/views/Songs.vue')         },
-		{ path: '/song/:id/:key?', name: 'song-show',     component: () => import('@/views/SongShow.vue')      },
-		{ path: '/setlists',       name: 'setlists',      component: () => import('@/views/Setlists.vue')      },
-		{ path: '/setlists/:year', name: 'setlists-year', component: () => import('@/views/Setlists.vue')      },
-		{ path: '/setlist/:id',    name: 'setlist-show',  component: () => import('@/views/SetlistShow.vue')   },
-		{ path: '/profile',        name: 'profile',       component: () => import('@/views/Profile.vue')       },
-		{ path: '/settings',       name: 'settings',      component: () => import('@/views/Settings.vue')      },
-		{ path: '/shortcuts',      name: 'shortcuts',     component: () => import('@/views/Shortcuts.vue')     },
-		{ path: '/documentation',  name: 'documentation', component: () => import('@/views/Documentation.vue') },
+		{ path: '/songs',                    name: 'songs',         component: () => import('@/views/Songs.vue')         },
+		{ path: '/songs/:tag',               name: 'songs-tag',     component: () => import('@/views/Songs.vue')         },
+		{ path: '/song/:id/:key?/:setlist?', name: 'song-show',     component: () => import('@/views/SongShow.vue')      },
+		{ path: '/setlists',                 name: 'setlists',      component: () => import('@/views/Setlists.vue')      },
+		{ path: '/setlists/:year',           name: 'setlists-year', component: () => import('@/views/Setlists.vue')      },
+		{ path: '/setlist/:id',              name: 'setlist-show',  component: () => import('@/views/SetlistShow.vue')   },
+		{ path: '/profile',                  name: 'profile',       component: () => import('@/views/Profile.vue')       },
+		{ path: '/settings',                 name: 'settings',      component: () => import('@/views/Settings.vue')      },
+		{ path: '/shortcuts',                name: 'shortcuts',     component: () => import('@/views/Shortcuts.vue')     },
+		{ path: '/documentation',            name: 'documentation', component: () => import('@/views/Documentation.vue') },
 	]
 })

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -241,7 +241,14 @@
 						<template v-if="songs[element.id]">
 							<td
 								class="cursor-pointer px-3 py-2 max-w-0"
-								@click="router.push({ name: 'song-show', params: { id: element.id, key: element.tuning ? element.tuning : songs[element.id].tuning }})"
+								@click="router.push({
+									name: 'song-show',
+									params: {
+										id: element.id,
+										key: element.tuning ? element.tuning : songs[element.id].tuning,
+										setlist: setlistKey,
+									}
+								})"
 							>
 								<div class="truncate">
 									<span>{{ songs[element.id].title }}</span>

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -231,7 +231,7 @@
 				handle=".handle"
 				ghost-class="!bg-blade-950"
 			>
-				<template #item="{ element }">
+				<template #item="{ element, index }">
 					<tr
 						class="even:bg-blade-200/50 even:dark:bg-blade-900/50 hover:bg-blade-200 hover:dark:bg-blade-900 transition-all"
 					>
@@ -259,7 +259,7 @@
 									<secondary-button
 										v-if="user && role > 1"
 										class="!px-2"
-										@click.prevent="transposeDown(songs[element.id], i)"
+										@click.prevent="transposeDown(songs[element.id], index)"
 									>
 										<icon-chevron-left class="w-5 h-5" />
 									</secondary-button>
@@ -269,7 +269,7 @@
 									<secondary-button
 										v-if="user && role > 1"
 										class="!px-2"
-										@click.prevent="transposeUp(songs[element.id], i)"
+										@click.prevent="transposeUp(songs[element.id], index)"
 									>
 										<icon-chevron-right class="w-5 h-5" />
 									</secondary-button>

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -8,11 +8,14 @@
 			<!-- title and visible setlist count -->
 			<div
 				v-if="ready.setlists && setlist"
-				class="flex flex-col xs:flex-row gap-x-6 gap-y-0 text-3xl uppercase font-thin tracking-wider"
+				class="text-3xl uppercase font-thin tracking-wider"
 			>
-				<span class="font-semibold">{{ setlist.title }}</span>
-				{{ t('object.song', setlist.songs.length, { n: setlist.songs.length }) }}
+				<span class="font-semibold mr-4">{{ setlist.title }}</span>
+				<span class="inline-block whitespace-nowrap">
+					{{ t('object.song', setlist.songs.length, { n: setlist.songs.length }) }}
+				</span>
 			</div>
+			<!-- setlist meta data -->
 			<div class="flex flex-wrap gap-x-4 gap-y-2 -mt-2 -mb-2">
 				<div
 					v-if="setlist.private"
@@ -258,7 +261,7 @@
 										class="!px-2"
 										@click.prevent="transposeDown(songs[element.id], i)"
 									>
-										<icon-arrow-left class="w-5 h-5" />
+										<icon-chevron-left class="w-5 h-5" />
 									</secondary-button>
 									<div class="font-mono font-semibold text-xl w-6 text-center">
 										{{ element.tuning ? element.tuning : songs[element.id].tuning }}
@@ -268,7 +271,7 @@
 										class="!px-2"
 										@click.prevent="transposeUp(songs[element.id], i)"
 									>
-										<icon-arrow-right class="w-5 h-5" />
+										<icon-chevron-right class="w-5 h-5" />
 									</secondary-button>
 								</div>
 							</td>
@@ -458,10 +461,11 @@ import SetlistPresent from '@/modals/SetlistPresent.vue';
 // icons
 import {
 	IconArrowLeft,
-	IconArrowRight,
 	IconBrandSlack,
 	IconCalendarEvent,
 	IconChevronDown,
+	IconChevronLeft,
+	IconChevronRight,
 	IconClipboard,
 	IconCopy,
 	IconDownload,

--- a/src/views/SetlistShow.vue
+++ b/src/views/SetlistShow.vue
@@ -230,6 +230,7 @@
 				item-key="id"
 				handle=".handle"
 				ghost-class="!bg-blade-950"
+				@end="saveOrder"
 			>
 				<template #item="{ element, index }">
 					<tr
@@ -631,10 +632,8 @@ const noSongs = computed(() => {
 	return props.ready.songs && props.ready.setlists && setlist.value && setlist.value.songs.length == 0;
 });
 
-// handle drag and drop reorder event and save new order for setlist
-const reorder = ({oldIndex, newIndex}) => {
-	const movedItem = setlist.value.songs.splice(oldIndex, 1)[0];
-	setlist.value.songs.splice(newIndex, 0, movedItem);
+// save new song order for setlist
+const saveOrder = () => {
 	db.collection('setlists').doc(route.params.id).set(
 		{ songs: setlist.value.songs },
 		{ merge: true }

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -3,8 +3,8 @@
 		<!-- page heading -->
 		<div class="flex flex-col justify-between items-stretch gap-4">
 			<!-- title and song count -->
-			<div class="flex gap-6 text-3xl uppercase font-thin tracking-wider">
-				<span class="font-semibold">{{ song.title }}</span>
+			<div class="text-3xl uppercase font-thin tracking-wider">
+				<span class="font-semibold mr-4">{{ song.title }}</span>
 				{{ showTuning.current }}
 			</div>
 			<div class="text-blade-500 -mt-4">{{ song.subtitle }}</div>
@@ -33,7 +33,7 @@
 						:title="t('tooltip.transposeDown')"
 						@click="tuning--"
 					>
-						<icon-arrow-left />
+						<icon-chevron-left />
 					</secondary-button>
 					<secondary-button
 						:disabled="!chords"
@@ -47,7 +47,7 @@
 						:title="t('tooltip.transposeUp')"
 						@click="tuning++"
 					>
-						<icon-arrow-right />
+						<icon-chevron-right />
 					</secondary-button>
 					<div class="absolute top-11 left-1/2 -translate-x-1/2 w-40 flex justify-between p-1 rounded-lg bg-blade-200 dark:bg-blade-900 invisible group-hover:visible">
 						<div class="flex-auto basis-0 font-mono text-center text-xl text-blade-500 px-3">
@@ -234,8 +234,9 @@ import SongPresent from '@/modals/SongPresent.vue';
 // icons
 import {
 	IconArrowLeft,
-	IconArrowRight,
 	IconChevronDown,
+	IconChevronLeft,
+	IconChevronRight,
 	IconCopy,
 	IconDownload,
 	IconEdit,

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -27,25 +27,28 @@
 				</secondary-button>
 			</div>
 			<div class="flex items-center gap-1">
-				<div class="group flex items-center gap-1 relative key-preview">
+				<div class="group flex items-center relative key-preview">
 					<secondary-button
+						class="!px-2 rounded-r-none"
 						:disabled="!chords"
 						:title="t('tooltip.transposeDown')"
-						@click="tuning--"
+						@click="transposeDown"
 					>
 						<icon-chevron-left />
 					</secondary-button>
 					<secondary-button
+						class="!px-2 border-x border-x-blade-500 dark:border-x-blade-800 rounded-none"
 						:disabled="!chords"
 						:title="t('tooltip.keyReset')"
-						@click="tuning = 0"
+						@click="transposeReset"
 					>
 						<icon-reload />
 					</secondary-button>
 					<secondary-button
+						class="!px-2 rounded-l-none"
 						:disabled="!chords"
 						:title="t('tooltip.transposeUp')"
-						@click="tuning++"
+						@click="transposeUp"
 					>
 						<icon-chevron-right />
 					</secondary-button>
@@ -301,8 +304,8 @@ const props = defineProps({
 const emit = defineEmits(['started', 'editSong', 'editSetlist']);
 
 // reactive data
-const chords   = ref(true);
-const tuning   = ref(0);
+const chords = ref(true);
+const tuning = ref(0);
 const modal = reactive({
 	song: {},
 	delete: false,
@@ -340,17 +343,31 @@ const showLanguages = computed(() => {
 	}
 });
 // show current key as well as previous and next key for transposing keys
+const keyIndexOnScale = (index) => {
+	return keyScale[(12 + keyScale.indexOf(song.value.tuning) + (index % 12)) % 12]
+};
 const showTuning = computed(() => {
 	if (song.value) {
 		return {
-			previous: keyScale[(12 + keyScale.indexOf(song.value.tuning) + (tuning.value-1 % 12)) % 12],
-			current: keyScale[(12 + keyScale.indexOf(song.value.tuning) + (tuning.value % 12)) % 12],
-			next: keyScale[(12 + keyScale.indexOf(song.value.tuning) + (tuning.value+1 % 12)) % 12],
+			previous: keyIndexOnScale(tuning.value-1),
+			current: keyIndexOnScale(tuning.value),
+			next: keyIndexOnScale(tuning.value+1),
 		};
 	} else {
 		return {}
 	}
 });
+
+// handle transposition
+const transposeDown = () => {
+	tuning.value--;
+};
+const transposeUp = () => {
+	tuning.value++;
+};
+const transposeReset = () => {
+	tuning.value = 0;
+};
 
 // calculates difference between song key and url key parameter and returns new key scale index
 const urlKeyDiff = () => {

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -190,14 +190,11 @@
 		<div class="flex justify-end">
 			<zone-info
 				v-if="urlSetlist && ready.setlists && ready.songs"
-				:label="'On Setlist: ' + setlists[urlSetlist].title"
+				:label="`${t('page.setlists', 1)}: ${setlists[urlSetlist].title}, song #${position+1}`"
 				@close="goToBasicSong"
 				closable
 			>
-				<div class="flex justify-end items-center gap-4">
-					<div>
-						Position {{ position+1 }}
-					</div>
+				<div class="flex justify-end items-center">
 					<div class="flex gap-1">
 						<!-- back navigation -->
 						<secondary-button
@@ -207,7 +204,7 @@
 							@click="goToPreviousSong"
 						>
 							<icon-arrow-left />
-							<div v-if="position > 0" class="hidden lg:flex items-center gap-2">
+							<div v-if="position > 0" class="hidden sm:flex items-center gap-2">
 								<div class="max-w-3xs truncate">
 									{{ songs[setlists[urlSetlist]?.songs[position-1]?.id]?.title }}
 								</div>
@@ -223,7 +220,7 @@
 							title="Next Song"
 							@click="goToNextSong"
 						>
-							<div v-if="position < setlists[urlSetlist].songs.length-1" class="hidden lg:flex items-center gap-2">
+							<div v-if="position < setlists[urlSetlist].songs.length-1" class="hidden sm:flex items-center gap-2">
 								<div class="max-w-3xs truncate">
 									{{ songs[setlists[urlSetlist]?.songs[position+1]?.id]?.title }}
 								</div>

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -190,10 +190,18 @@
 		<div class="flex justify-end">
 			<zone-info
 				v-if="urlSetlist && ready.setlists && ready.songs && songInUrlSetlist"
-				:label="`${t('page.setlists', 1)}: ${setlists[urlSetlist].title}, song #${position+1}`"
 				@close="goToBasicSong"
 				closable
 			>
+				<template #label>
+					<router-link
+						class="text-blade-600 dark:text-blade-400 mr-1"
+						:to="{ name: 'setlist-show', params: { id: urlSetlist }}"
+					>
+						{{ t('page.setlists', 1) }}: {{ setlists[urlSetlist].title }}
+					</router-link>
+					{{ t('page.songs', 1) }} #{{ position+1 }}
+				</template>
 				<div class="flex justify-end items-center">
 					<div class="flex gap-1">
 						<!-- back navigation -->

--- a/src/views/SongShow.vue
+++ b/src/views/SongShow.vue
@@ -187,12 +187,8 @@
 			</div>
 		</div>
 		<!-- setlist navigation -->
-		<div class="flex justify-end">
-			<zone-info
-				v-if="urlSetlist && ready.setlists && ready.songs && songInUrlSetlist"
-				@close="goToBasicSong"
-				closable
-			>
+		<div v-if="urlSetlist && ready.setlists && ready.songs && songInUrlSetlist" class="flex justify-end">
+			<zone-info @close="goToBasicSong" closable>
 				<template #label>
 					<router-link
 						class="text-blade-600 dark:text-blade-400 mr-1"


### PR DESCRIPTION
<!--
* Filling out this template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds an info box which provides links to navigate forwards or backwards within a setlist and a link back to the setlist. This box only appears, when opening a song on a setlist. It is closable.

![image](https://user-images.githubusercontent.com/5441654/234751886-a7b34d23-e658-4eb2-9bdd-8752775ecbf0.png)

Also the loading of the correct key for the song was fixed and the storage of the song order when dragging songs in setlist view.

## Benefits

Quicker navigation between songs from the same setlist.

## Applicable Issues

Closes #168 
