### PR TITLE
OpenLP service list export for setlists

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
 				"@vuepic/vue-datepicker": "^8.1.1",
 				"@vueuse/core": "^10.2.1",
 				"@vueuse/math": "^10.2.1",
+				"@zip.js/zip.js": "^2.7.45",
 				"chart.js": "^4.0.1",
 				"date-fns": "^3.2.0",
 				"firebase": "^10.0.0",
@@ -1882,6 +1883,16 @@
 				"@vue/composition-api": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@zip.js/zip.js": {
+			"version": "2.7.45",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.45.tgz",
+			"integrity": "sha512-Mm2EXF33DJQ/3GWWEWeP1UCqzpQ5+fiMvT3QWspsXY05DyqqxWu7a9awSzU4/spHMHVFrTjani1PR0vprgZpow==",
+			"engines": {
+				"bun": ">=0.7.0",
+				"deno": ">=1.0.0",
+				"node": ">=16.5.0"
 			}
 		},
 		"node_modules/ansi-regex": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
 		"@vuepic/vue-datepicker": "^8.1.1",
 		"@vueuse/core": "^10.2.1",
 		"@vueuse/math": "^10.2.1",
+		"@zip.js/zip.js": "^2.7.45",
 		"chart.js": "^4.0.1",
 		"date-fns": "^3.2.0",
 		"firebase": "^10.0.0",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -38,6 +38,7 @@
     "filetypeSng": "SongBeamer-Datei [.sng]",
     "filetypeTxt": "Text-Datei [.txt]",
     "filetypeXml": "OpenLyrics-Datei [.xml]",
+    "filetypeOsz": "OpenLP Service [.osz]",
     "formatMarkdown": "Als Markdown formatiert",
     "formatPlain": "Reines Textformat",
     "formatSlack": "Für Slack formatiert",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -38,6 +38,7 @@
     "filetypeSng": "SongBeamer file [.sng]",
     "filetypeTxt": "Plain text file [.txt]",
     "filetypeXml": "OpenLyrics file [.xml]",
+    "filetypeOsz": "OpenLP Service [.osz]",
     "formatMarkdown": "Markdown formatted",
     "formatPlain": "As plain text",
     "formatSlack": "Slack formatted",

--- a/frontend/src/views/SongShow.vue
+++ b/frontend/src/views/SongShow.vue
@@ -286,7 +286,7 @@
 </template>
 
 <script setup>
-import { keyScale, isChordLine, parsedContent, download } from '@/utils.js';
+import { keyScale, isChordLine, parsedContent, download, openLyricsXML } from '@/utils.js';
 import { logicAnd, logicOr } from '@vueuse/math';
 import { notify } from '@kyvg/vue3-notification';
 import { ref, reactive, computed, inject, onMounted } from 'vue';
@@ -524,38 +524,8 @@ const exportSng = () => {
 };
 // export song in OpenLyrics XML format
 const exportXml = () => {
-	// add header
-	const timestamp = (new Date()).toISOString().slice(0, -5);
-	const title = `<title>${song.value.title}</title>`;
-	const subtitle = song.value.subtitle ? `<title>${song.value.subtitle}</title>` : '';
-	const year = song.value.year ? `<released>${song.value.year}</released>` : '';
-	const copyright = song.value.year || song.value.publisher
-		? '<copyright>' + song.value.year + ' ' + song.value.publisher.replace(/(?:\r\n|\r|\n)/g, '; ') + '</copyright>'
-		: '';
-	const ccli = song.value.ccli ? `<ccliNo>${song.value.ccli}</ccliNo>` : '';
-	const authors = song.value.authors
-		? '<authors>' + song.value.authors.split('|').map(a => `<author>${a.trim()}</author>`).join('') + '</authors>'
-		: '';
-	const tags = song.value.tags
-		? '<themes>' + song.value.tags.map(
-				tag => availableLocales.map(l =>`<theme lang="${l}">${props.tags[tag][l] ?? tag.key}</theme>`).join('')
-			).join('') + '</themes>'
-		: '';
-	const lyrics = parsedContent(song.value.content, song.value.tuning, false, false).map(p => {
-		const num = p.number > 0 ? p.number : '1';
-		return `<verse name="${p.type}${num}"><lines>` + p.content.replace(/\n/g, "<br />") + '</lines></verse>'
-	}).join('');
-	const content = `<?xml version='1.0' encoding='UTF-8'?>
-		<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="SongDrive ${version}" modifiedIn="SongDrive ${version}" modifiedDate="${timestamp}">
-			<properties>
-				<titles>${title}${subtitle}</titles>
-				${copyright}${year}${ccli}${authors}${tags}
-			</properties>
-			<lyrics>${lyrics}</lyrics>
-		</song>
-	`;
 	// start download
-	download(content, songId + '.xml');
+	download(openLyricsXML(song.value, version, availableLocales, props.tags), songId + '.xml');
 	// toast success message
 	notify({
 		title: t('toast.exportedXml'),


### PR DESCRIPTION
<!--
* Filling out this template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change extends the options for exporting a setlist with an export as OpenLP service list (`.osz`).

## Benefits

Folks who use OpenLP can now one-click-import a whole setlist including all songs into their OpenLP song database.

## Applicable Issues

Closes #216 