### PR TITLE
Multilang openlp export

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -331,6 +331,7 @@ const browserPrefersDark = () => {
 const mailto = (address) => window.location.href = 'mailto:' + address;
 
 // build OpenLyrics XML for given song
+// see https://manual.openlp.org/display_tags.html#configuring-formatting-tags
 const openLyricsXML = (song, version, translatedSong = null, locales = [], allTags = null) => {
 	const timestamp = (new Date()).toISOString().slice(0, -5);
 	const title = `<title>${song.title}</title>`;
@@ -345,16 +346,18 @@ const openLyricsXML = (song, version, translatedSong = null, locales = [], allTa
 		: '';
 	const tags = song.tags && locales && allTags
 		? '<themes>' + song.tags.map(
-				tag => locales.map(l =>`<theme lang="${l}">${allTags[tag][l] ?? tag.key}</theme>`).join('')
+				tag => locales.map(l =>`<theme lang='${l}'>${allTags[tag][l] ?? tag.key}</theme>`).join('')
 			).join('') + '</themes>'
 		: '';
-  const format = translatedSong ? `<format><tags application='OpenLP'><tag name='it'><open>&lt;em&gt;</open><close>&lt;/em&gt;</close><hidden>False</hidden></tag><tag name='gr'><open>&lt;span style='-webkit-text-fill-color:#c2c2a3'&gt;</open><close>&lt;/span&gt;</close><hidden>False</hidden></tag></tags></format>` : '';
+  const format = translatedSong
+    ? `<format><tags application='OpenLP'><tag name='it'><open><![CDATA[<em>]]></open><close><![CDATA[</em>]]></close><hidden><![CDATA[False]]></hidden></tag><tag name='gr'><open><![CDATA[<span style='-webkit-text-fill-color:grey'>]]></open><close><![CDATA[</span>]]></close><hidden><![CDATA[True]]></hidden></tag><tag name='fd'><open><![CDATA[<small>]]></open><close><![CDATA[</small>]]></close><hidden><![CDATA[True]]></hidden></tag></tags></format>`
+    : '';
   const tParts = translatedSong ? parsedContent(translatedSong.content, 0, false, false) : [];
 	const lyrics = parsedContent(song.content, 0, false, false).map((p, i) => {
 		const type = p.type ? p.type.toUpperCase() : 'V';
 		const num = p.number > 0 ? p.number : '1';
     const tContent = (i in tParts)
-      ? `<br/><br/><tag name='it'><tag name='gr'>${tParts[i].content.replace(/\n/g, "<br />")}</tag></tag>`
+      ? `<br/><br/><tag name='it'><tag name='gr'><tag name='fd'>${tParts[i].content.replace(/\n/g, "<br />")}</tag></tag></tag>`
       : '';
 		return `<verse name='${type}${num}'><lines>${p.content.replace(/\n/g, "<br />")}${tContent}</lines></verse>`;
 	}).join('');

--- a/frontend/src/views/SetlistShow.vue
+++ b/frontend/src/views/SetlistShow.vue
@@ -994,7 +994,7 @@ const exportOsz = async () => {
 			const tParts = tSong ? parsedContent(tSong.content, 0, false, false) : [];
 			parts.forEach((part, i) => {
 				itemData.push({
-					'raw_slide': (i in tParts) ? part.content + "\n\n" + tParts[i].content : part.content,
+					'raw_slide': (i in tParts) ? `${part.content}\n\n{it}{gr}{fd}${tParts[i].content}{/fd}{/it}{/gr}` : part.content,
 					'verseTag': (part.type ? part.type.toUpperCase() : 'V') + (part.number > 0 ? part.number.toString() : '1'),
 				});
 			});

--- a/frontend/src/views/SetlistShow.vue
+++ b/frontend/src/views/SetlistShow.vue
@@ -545,13 +545,13 @@ const emit = defineEmits(['editSong', 'editSetlist']);
 
 // component properties
 const props = defineProps({
-  languages:     Object,
-  ready:         Object,
-  role:          Number,
-  setlists:      Object,
-  songs:         Object,
-  user:          String,
-  users:         Object,
+  languages: Object,
+  ready:     Object,
+  role:      Number,
+  setlists:  Object,
+  songs:     Object,
+  user:      String,
+  users:     Object,
 });
 
 // reactive data
@@ -981,12 +981,20 @@ const exportOsz = async () => {
 		if (setlist.value.songs.hasOwnProperty(key) && setlist.value.songs[key].id in props.songs) {
 			// get song object
 			const song = props.songs[setlist.value.songs[key].id];
+			// check for translations
+			const lang = !('lang' in localStorage) ? locale.value : localStorage.getItem('lang');
+			let tSong = null;
+			if (lang !== song.language && song.translations.length > 0) {
+				const tKey = song.translations.find((t) => t.endsWith(`-${lang}`));
+				tSong = props.songs[tKey];
+			}
 			// handle song content parts
-			let itemData = [];
-			let parts = parsedContent(song.content, 0, false, false);
-			parts.forEach((part) => {
+			const itemData = [];
+			const parts = parsedContent(song.content, 0, false, false);
+			const tParts = tSong ? parsedContent(tSong.content, 0, false, false) : [];
+			parts.forEach((part, i) => {
 				itemData.push({
-					'raw_slide': part.content,
+					'raw_slide': (i in tParts) ? part.content + "\n\n" + tParts[i].content : part.content,
 					'verseTag': (part.type ? part.type.toUpperCase() : 'V') + (part.number > 0 ? part.number.toString() : '1'),
 				});
 			});
@@ -1014,7 +1022,7 @@ const exportOsz = async () => {
 							'ccli_number': song.ccli,
 							'copyright': song.publisher
 						},
-						'xml_version': openLyricsXML(song, version),
+						'xml_version': openLyricsXML(song, version, tSong),
 						'auto_play_slides_once': false,
 						'auto_play_slides_loop': false,
 						'timed_slide_interval': 0,

--- a/frontend/src/views/SongShow.vue
+++ b/frontend/src/views/SongShow.vue
@@ -524,8 +524,15 @@ const exportSng = () => {
 };
 // export song in OpenLyrics XML format
 const exportXml = () => {
+	// check for translations
+	const lang = !('lang' in localStorage) ? locale.value : localStorage.getItem('lang');
+	let tSong = null;
+	if (lang !== song.value.language && song.value.translations.length > 0) {
+		const tKey = song.value.translations.find((t) => t.endsWith(`-${lang}`));
+		tSong = props.songs[tKey];
+	}
 	// start download
-	download(openLyricsXML(song.value, version, null, availableLocales, props.tags), songId + '.xml');
+	download(openLyricsXML(song.value, version, tSong, availableLocales, props.tags), songId + '.xml');
 	// toast success message
 	notify({
 		title: t('toast.exportedXml'),

--- a/frontend/src/views/SongShow.vue
+++ b/frontend/src/views/SongShow.vue
@@ -525,7 +525,7 @@ const exportSng = () => {
 // export song in OpenLyrics XML format
 const exportXml = () => {
 	// start download
-	download(openLyricsXML(song.value, version, availableLocales, props.tags), songId + '.xml');
+	download(openLyricsXML(song.value, version, null, availableLocales, props.tags), songId + '.xml');
 	// toast success message
 	notify({
 		title: t('toast.exportedXml'),


### PR DESCRIPTION
<!--
* Filling out this template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change extends the OpenLyrics XML song export and OpenLP setlist export with translated song parts, if the song languages differs from the user defined SongDrive language.

## Benefits

Less effort on creating OpenLP setlists.

## Applicable Issues

Closes #220 
