### PR TITLE
Link in setlist exports 

### DIFF
--- a/frontend/src/views/SetlistShow.vue
+++ b/frontend/src/views/SetlistShow.vue
@@ -799,6 +799,10 @@ const copyList = (format) => {
 			}
 		}
 	);
+	// Add link to list
+	list.push(...['', format === 'markdown' ? `<${window.location}>` : window.location]);
+
+	// Copy to clipboard
 	navigator.clipboard.writeText(list.join('\n'));
 	notify({
 		title: t('toast.copiedToClipboard'),

--- a/frontend/src/views/SetlistShow.vue
+++ b/frontend/src/views/SetlistShow.vue
@@ -800,7 +800,7 @@ const copyList = (format) => {
 		}
 	);
 	// Add link to list
-	list.push(...['', format === 'markdown' ? `<${window.location}>` : window.location]);
+	list.push(...['', format === 'markdown' ? `<${window.location.href}>` : window.location.href]);
 
 	// Copy to clipboard
 	navigator.clipboard.writeText(list.join('\n'));
@@ -837,6 +837,13 @@ const exportPdf = (mode) => {
 				lineHeight: 1.4,
 				margin: [ 0, 30, 0, 5 ]
 			},
+			link: {
+				font: 'FiraSans',
+				fontSize: 11,
+				lineHeight: 1.4,
+				color: '#759B3B',
+				margin: [ 0, 20, 0, 0 ],
+			},
 			partnumber: {
 				font: 'FiraSans',
 				fontSize: 24,
@@ -859,12 +866,11 @@ const exportPdf = (mode) => {
 			}
 		}
 	};
-	pdfMake.createPdf(doc).download(
-		route.params.id
-		+ '-'
-		+ (mode == 'sheets' ? t('text.songsheets') : t('text.list')).toLowerCase()
-		+ '.pdf'
-	);
+
+	// Trigger download
+	const type = (mode == 'sheets' ? t('text.songsheets') : t('text.list')).toLowerCase();
+	pdfMake.createPdf(doc).download(`${route.params.id}-${type}.pdf`);
+
 	// toast success message
 	notify({
 		title: t('toast.exportedPdf'),
@@ -893,7 +899,8 @@ const getPdfSetlist = () => {
 			style: 'subtitle',
 			margin: [ 0, 6, 0, 0 ]
 		},
-		{ ol: songs, style: 'list'}
+		{ ol: songs, style: 'list'},
+		{ text: window.location.href, link: window.location.href, style: 'link' },
 	];
 };
 


### PR DESCRIPTION
<!--
* Filling out this template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR adds a link to the setlist to the copy setlist and pdf list export tools.

## Benefits

The link to the setlist doesn't have to be copied and shared manually / separately anymore.

## Applicable Issues

Closes #158 
